### PR TITLE
Update to 4.6.0 (with patch) and .NET 8

### DIFF
--- a/fix-ci-build-avalonia-version.patch
+++ b/fix-ci-build-avalonia-version.patch
@@ -1,0 +1,13 @@
+diff --git a/GalaxyBudsClient/GalaxyBudsClient.csproj b/GalaxyBudsClient/GalaxyBudsClient.csproj
+index bcbdd43..890f626 100644
+--- a/GalaxyBudsClient/GalaxyBudsClient.csproj
++++ b/GalaxyBudsClient/GalaxyBudsClient.csproj
+@@ -87,7 +87,7 @@
+     <PropertyGroup>
+         <!-- https://github.com/AvaloniaUI/Avalonia/commit/76caeedfd2baf1911f889011189d1c21657d2987,
+             last release at time of writing is 11.0.9, so anything newer should include a fix -->
+-        <AvaloniaVersion>11.1.999-cibuild0045273-beta</AvaloniaVersion>
++        <AvaloniaVersion>11.1.0-beta1</AvaloniaVersion>
+     </PropertyGroup>
+     <ItemGroup>
+         <PackageReference Include="Avalonia" Version="$(AvaloniaVersion)" />

--- a/me.timschneeberger.GalaxyBudsClient.yaml
+++ b/me.timschneeberger.GalaxyBudsClient.yaml
@@ -4,7 +4,7 @@ runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: GalaxyBudsClient
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.dotnet6
+  - org.freedesktop.Sdk.Extension.dotnet8
 finish-args:
   - --socket=x11 # https://github.com/AvaloniaUI/Avalonia/issues/1243 😔
   - --share=ipc
@@ -17,13 +17,15 @@ finish-args:
   - --talk-name=com.canonical.Unity.LauncherEntry
   - --talk-name=org.kde.StatusNotifierWatcher
   - --own-name=org.kde.*
-  - --filesystem=xdg-download:ro # xdg-desktop-portal integration only available starting with Avalonia 11.0.0-rc1.1
 modules:
   - name: GalaxyBudsClient
     sources:
       - type: git
         url: https://github.com/ThePBone/GalaxyBudsClient
-        commit: cbc874f27c9e907b76a5fda3c9c0d4dca0ac5484
+        tag: 4.6.0
+        commit: 03742b2902d50a7f13b00c1450cf47298f60fc67
+      - type: patch
+        path: fix-ci-build-avalonia-version.patch
       - sources-arm64.json
       - sources-x64.json
     buildsystem: simple
@@ -36,8 +38,8 @@ modules:
           env:
             RID: arm64
     build-commands:
-      - '. /usr/lib/sdk/dotnet6/enable.sh ; dotnet publish -r linux-$RID -c Release -p:PublishTrimmed=true --self-contained true --source ./nuget-sources GalaxyBudsClient/GalaxyBudsClient.csproj'
-      - 'cp -r --remove-destination /run/build/GalaxyBudsClient/GalaxyBudsClient/bin/Release/net6.0/linux-$RID/publish/ /app/bin/'
+      - '. /usr/lib/sdk/dotnet8/enable.sh ; dotnet publish -r linux-$RID -c Release --self-contained true --source ./nuget-sources GalaxyBudsClient/GalaxyBudsClient.csproj'
+      - 'cp -r --remove-destination /run/build/GalaxyBudsClient/GalaxyBudsClient/bin/Release/net8.0/linux-$RID/publish/ /app/bin/'
       - install -Dm644 meta/flatpak/me.timschneeberger.GalaxyBudsClient.metainfo.xml /app/share/metainfo/me.timschneeberger.GalaxyBudsClient.metainfo.xml
       - install -Dm644 GalaxyBudsClient/Resources/icon_white.png /app/share/icons/hicolor/128x128/apps/me.timschneeberger.GalaxyBudsClient.png
       - install -Dm644 meta/flatpak/me.timschneeberger.GalaxyBudsClient.desktop /app/share/applications/me.timschneeberger.GalaxyBudsClient.desktop

--- a/sources-arm64.json
+++ b/sources-arm64.json
@@ -1,255 +1,304 @@
 [
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia/0.10.18/avalonia.0.10.18.nupkg",
-        "sha512": "bfa398495373162d13add9a15c4b65016a08b5405206d45225952ac202ad66fa7e5d157ce3bbf19d78b00389a33e32dee697884144b0678af7f61508826ceb5c",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia/11.1.0-beta1/avalonia.11.1.0-beta1.nupkg",
+        "sha512": "d375b952be419fef340c9f06c5e31ab43fb878d81a3901b640f9f7524fd6f656b3185fe21a0275f85d84ec7b8ca4f0b7d56be29be53434944bb9b2bc3775b887",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.0.10.18.nupkg"
+        "dest-filename": "avalonia.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.angle.windows.natives/2.1.0.2020091801/avalonia.angle.windows.natives.2.1.0.2020091801.nupkg",
-        "sha512": "185412856ea8f3001b19ff03261fa84d3b7b529a2a0eb0a0eada93eac5761e11056f2080373ac5a11449250aadcf61631875e4ca8d5ac5f0e7ef39bd09e93430",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.angle.windows.natives/2.1.22045.20230930/avalonia.angle.windows.natives.2.1.22045.20230930.nupkg",
+        "sha512": "82bb927cff47738cd13ee87f93664eed203fe0586c807c0fb2215e743b01d787c1ab8285512c82a3f891dbd303a20eb1feb24fdfe09a9edd91d9de65ce96f4d7",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.angle.windows.natives.2.1.0.2020091801.nupkg"
+        "dest-filename": "avalonia.angle.windows.natives.2.1.22045.20230930.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.controls.datagrid/0.10.18/avalonia.controls.datagrid.0.10.18.nupkg",
-        "sha512": "44f28349f55156448fea48ea5999d13cc7ab23ed4105ddeccf8b4ee8bb9f05dafe6be3a9375db843758eab17cf3a0efb282ab76896cd6befbfa887c7bc9231ee",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.buildservices/0.0.29/avalonia.buildservices.0.0.29.nupkg",
+        "sha512": "9485e64c84b087beaf0803c049e9c057216b889bb8d452f0339149dbde65b2c9f1cca2f2b119c3d1eb8c6eb135f582edc72516095bb6be9a2d3b530d3aa3d639",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.controls.datagrid.0.10.18.nupkg"
+        "dest-filename": "avalonia.buildservices.0.0.29.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.desktop/0.10.18/avalonia.desktop.0.10.18.nupkg",
-        "sha512": "c33d01e4e766a1bdcf642100bff4cf1c5a868736375a2dd5305c131e265e1cfe69a0d1b2ea4f83104434a066cee33c391bd5968b707ad0699992c0b1662ff118",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.controls.colorpicker/11.1.0-beta1/avalonia.controls.colorpicker.11.1.0-beta1.nupkg",
+        "sha512": "ce1eb2c6d88a33652b61e2215bc38e53d32371e9c99fc101c5d1e53816755f712de7c5f27047180a64f17139635097328fb3717a7af83c6b033a9a79b8bb0729",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.desktop.0.10.18.nupkg"
+        "dest-filename": "avalonia.controls.colorpicker.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.diagnostics/0.10.18/avalonia.diagnostics.0.10.18.nupkg",
-        "sha512": "14ba2ec4aa8ca1756d8a766b48af226fc978502656dff50789bceb064112fb6c4ca7db492f3ebf66fb40b49a9e96d1b8ccafca12587691e2f1b2d57cc5a8d756",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.controls.datagrid/11.1.0-beta1/avalonia.controls.datagrid.11.1.0-beta1.nupkg",
+        "sha512": "d36fcb92469db88f97732b146722a05e1adbaae3993f75a9e0fbf282c9af5ab4d8228e17850206cbd77c7e0b48fdd4bced51be80b432a5a66748323296ea8796",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.diagnostics.0.10.18.nupkg"
+        "dest-filename": "avalonia.controls.datagrid.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.freedesktop/0.10.18/avalonia.freedesktop.0.10.18.nupkg",
-        "sha512": "ce5edac45a9069ec62cbb843ad4ae310ad407785b6ad8afe23bf98c6b28ab9b6d067f313f0432db605e0c9e444ceaad8f77f7dda1839bd3e97da635cbd9e6afa",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.desktop/11.1.0-beta1/avalonia.desktop.11.1.0-beta1.nupkg",
+        "sha512": "4b3f977c76947d996a9245de4f82d150a587150047510b806cb7889b30eb8b83e36ff8cdf831e82ce78851e2dab55ef6059c590f17a57531c7650430147c5218",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.freedesktop.0.10.18.nupkg"
+        "dest-filename": "avalonia.desktop.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.markup.xaml.loader/0.10.18/avalonia.markup.xaml.loader.0.10.18.nupkg",
-        "sha512": "10f39212273470112788c70a924e0ceae03fb203688af4001b0106d34cd9c9b012e46e9e7b28239b43c65d9c8dac9c20c6f16c6a917ff9ef04a64fed0aaf350d",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.diagnostics/11.1.0-beta1/avalonia.diagnostics.11.1.0-beta1.nupkg",
+        "sha512": "b64cf69a7d0d2d18cf9e2e9d2dd37620024a5c42cbb6a58abbc0df02fe6c905a2c8389fc8b1cf678544eea0dbf84dd8befc187ead2b709dadc35dfa6334d516f",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.markup.xaml.loader.0.10.18.nupkg"
+        "dest-filename": "avalonia.diagnostics.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.native/0.10.18/avalonia.native.0.10.18.nupkg",
-        "sha512": "9bba27cbd6b0082157ed3f5c3d8d02a11f98e4148aef11062daee11c4f763919e89e1bbe124581bcfd611151faecc037835f38099ee026467e5c07ce094ba522",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.fonts.inter/11.1.0-beta1/avalonia.fonts.inter.11.1.0-beta1.nupkg",
+        "sha512": "26c97f558cd54b653e1479546e3ebfdc3020227b6aa2384443dd44e9f1e63b49fd987e20ae9ce53cf3e72535d9feac871ccc61ca25d309cfa9955f54719eaa6e",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.native.0.10.18.nupkg"
+        "dest-filename": "avalonia.fonts.inter.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.remote.protocol/0.10.18/avalonia.remote.protocol.0.10.18.nupkg",
-        "sha512": "3d4ccc0821212b7e13dce1a7bdd2fd616ad18c111989389080cd95922198ed3aa57617740aff08c77c15f65c5790373be752614fe2956efbbeb133a2f9b2d358",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.freedesktop/11.1.0-beta1/avalonia.freedesktop.11.1.0-beta1.nupkg",
+        "sha512": "f0cfb10e3e50d891cb4bc47e416d63d72418d069bb7bb04e69f8e7681fec4d4b7f6439d2a484204766715cd36cd889512f213fc3739498e7a560267d3d29b917",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.remote.protocol.0.10.18.nupkg"
+        "dest-filename": "avalonia.freedesktop.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.skia/0.10.16/avalonia.skia.0.10.16.nupkg",
-        "sha512": "e87d9143931370884c4e4b54b672938f07b24ae11da67c67441a45c55182d44858828ac66dab67a9313235b69af939cd5b77d09ab428911abab7c28f6e3ac06d",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.markup.xaml.loader/11.1.0-beta1/avalonia.markup.xaml.loader.11.1.0-beta1.nupkg",
+        "sha512": "fb2cd8a393e26b92e60c557defc333a990bfe25a3e9d67f1d143c13629b2e2c298cd946a205f26ab55e49545067366f8b238dbd3afef2a490e13c49fd96f3a0c",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.skia.0.10.16.nupkg"
+        "dest-filename": "avalonia.markup.xaml.loader.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.skia/0.10.18/avalonia.skia.0.10.18.nupkg",
-        "sha512": "eb60286c911526e60366e21aa3f99a439a916144f24ec99e050007f125cc8e45bafd9963bdd6cc4c897f35369aefacfb42976fff5ba795c80b0405027523fa7c",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.native/11.1.0-beta1/avalonia.native.11.1.0-beta1.nupkg",
+        "sha512": "05fbab0b3cf5aca8d020e26b65224d61dbb6ac2e8d5084adbf89f41ada641f4559a000dc7e54f565a5067e91faa1cb076c939b8b44d12567e4e3fe10053c7e7f",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.skia.0.10.18.nupkg"
+        "dest-filename": "avalonia.native.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.svg.skia/0.10.16/avalonia.svg.skia.0.10.16.nupkg",
-        "sha512": "dfb366224c847c2fcd4400b6b4e4f9ee5f24106d173254a76b9bc6f4b88b31c4846fd3686d079220741d89460c7d65ceaa9f6939c82f9624608668541bdc3aa0",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.remote.protocol/11.1.0-beta1/avalonia.remote.protocol.11.1.0-beta1.nupkg",
+        "sha512": "96ae5522db75b4298848be51196ee9a8f5b5021c91ec8a9f0d24c4fee8c074b7fdec03765df1152fbf7c090dc4630e72cd27a8c6bf050dfdca429b520bcef1e9",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.svg.skia.0.10.16.nupkg"
+        "dest-filename": "avalonia.remote.protocol.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.win32/0.10.18/avalonia.win32.0.10.18.nupkg",
-        "sha512": "4d5218edbb80420c9b90052bc1a6ecff2d8bb05598fb9bf93c7496ac196de4d3b83d3b52c286a1ccfa3c68117df32fb9789c492f8abb90c4bb457e108908a58d",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.skia/11.0.0/avalonia.skia.11.0.0.nupkg",
+        "sha512": "6fe1db10ed9422decd24fb60801d9b63651f0bd3f046a9e9d566d0816e7f3fb70eb4cf23db173537a5d5d8e1b75c2999793e5503648fa200a31806c6591b2723",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.win32.0.10.18.nupkg"
+        "dest-filename": "avalonia.skia.11.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.x11/0.10.18/avalonia.x11.0.10.18.nupkg",
-        "sha512": "3dd443fb5436c7362eac851527a08710a5d02d9fcca93b8d1667dcb2d9e477ef814e674285eef415cc52ac98f22b6cfe1f364462fc064052b0de666778acd4da",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.skia/11.1.0-beta1/avalonia.skia.11.1.0-beta1.nupkg",
+        "sha512": "a4a150a1192abad079ef0e763b718b97d63cbe71315ce7a46f96bc108555c23f1b8a6dbbfb54e6da5b97acee997cef8af23b4ca5485e887a284bc9622731d876",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.x11.0.10.18.nupkg"
+        "dest-filename": "avalonia.skia.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.behaviors/0.10.17/avalonia.xaml.behaviors.0.10.17.nupkg",
-        "sha512": "1061eccdd870b56e3b7e55ace8eb1499702c3f2656315cd3716fcf51868aa5140ed2e90bfc036721ddf52928e878b2a9c97f83df75f59aab39edf6a2b9ee21c2",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.svg.skia/11.0.0.13/avalonia.svg.skia.11.0.0.13.nupkg",
+        "sha512": "e6888dc587451a2fdb7bf708d7924fac5c121479cc9754958d96f6e4036c752b56a1e231b35b66519b5a6942993943f63611638e46986f33a3c9a9f436f913e9",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.xaml.behaviors.0.10.17.nupkg"
+        "dest-filename": "avalonia.svg.skia.11.0.0.13.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactions/0.10.17/avalonia.xaml.interactions.0.10.17.nupkg",
-        "sha512": "1b88d9644b330f75bb2bdb9b2ec815918b21339eb263457ca99ffca652ae90d33480a2cff0d8adf04e8cb936734cd47d670ce642f8dde22d5e432fae16185ec9",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.themes.fluent/11.1.0-beta1/avalonia.themes.fluent.11.1.0-beta1.nupkg",
+        "sha512": "774bb2f1928c859f3ea6a6d4ad17bd69ad3f56d3901c7cca456c6f163137b366be19499f08c118bee1fb01155e3344bb81048248faea34eb628f3be0b57d5b17",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.xaml.interactions.0.10.17.nupkg"
+        "dest-filename": "avalonia.themes.fluent.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactivity/0.10.17/avalonia.xaml.interactivity.0.10.17.nupkg",
-        "sha512": "62c18cc0a3c081dfee78e007fed17f2fbaa39a8599c0d130c4368ac319219ed4181b6a77c15f0d864d1fec6ed6853e9356683f9a440dd8f2c4bae2d7f00b7aef",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.themes.simple/11.1.0-beta1/avalonia.themes.simple.11.1.0-beta1.nupkg",
+        "sha512": "e2a06fc69aadbdd7840cd197e264a6379c9982ec215dad547e48595864c5dbf2db642bf728070ab3324a7d91c42635db0c2817feec6fcfc97f8303d8d4f54ccd",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.xaml.interactivity.0.10.17.nupkg"
+        "dest-filename": "avalonia.themes.simple.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/castle.core/4.4.0/castle.core.4.4.0.nupkg",
-        "sha512": "7626c347f82038bc29b0b2ae399937047aead260ed85ff8c107d36adbe901d729be59cd89a5f98ef45da2d1883c8374b6f286c81c044a5a2b69ab4b5dde9ce98",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.win32/11.1.0-beta1/avalonia.win32.11.1.0-beta1.nupkg",
+        "sha512": "1fc85025e0d00f1ae79a7a81ab5ca33d2e1d823ea91c14931552ca7cc3bd33deec0f033b0306dc994da8938a79d9eff6eaac3b8c884ab23a8403441ac9e8aeb4",
         "dest": "nuget-sources",
-        "dest-filename": "castle.core.4.4.0.nupkg"
+        "dest-filename": "avalonia.win32.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/config.net/4.15.0/config.net.4.15.0.nupkg",
-        "sha512": "4d9e4910f15dac857b811ece2b90e59a5c55a246a81ca093e635744f0b8b3737cb99235d60a2fb7f0a054c320cbb1c03d03d4c5c988c10553b594c6a813a0a9e",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.x11/11.1.0-beta1/avalonia.x11.11.1.0-beta1.nupkg",
+        "sha512": "f1f08b32ba67e60bdce50629d5ab215f2e196dc2ade8f400e66c039f8cdf12c04b6893f8ac0a3f23571045e70b30b969fe6e1f26d70edd8bfcb183b1e44de43f",
         "dest": "nuget-sources",
-        "dest-filename": "config.net.4.15.0.nupkg"
+        "dest-filename": "avalonia.x11.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/config.net.json/4.15.0/config.net.json.4.15.0.nupkg",
-        "sha512": "c0c4e218de8b4359ee8825dd6625ecee568cc2ca164bbf1ed9b7af1acee02f42bad35a5c8093e2d6d76de1a6d235ec87b338e50179b4f20e35d9db0d2ea1c12d",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.behaviors/11.0.6/avalonia.xaml.behaviors.11.0.6.nupkg",
+        "sha512": "452b63f4f45411e00fd57f6a6bf42ff7839f9dbef31683e5b4b2b5eb2c90fe2a579c9c5ccc7380eed05823268bfb35ce99bf06633c3de7e919ddd8c7ec8e4ee7",
         "dest": "nuget-sources",
-        "dest-filename": "config.net.json.4.15.0.nupkg"
+        "dest-filename": "avalonia.xaml.behaviors.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/cs-script.core/1.4.2-preview/cs-script.core.1.4.2-preview.nupkg",
-        "sha512": "4b9fb804ec36ccd392760acfd51a958632f58f72c3c5b00177aa16a187ed4ee40cdb0083e44de315aff0bf42541616de7523dc15ffab94b258f21211e3bc5432",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactions/11.0.6/avalonia.xaml.interactions.11.0.6.nupkg",
+        "sha512": "6c226ecc2717223e8e7b461b9f542abb397b199d869bc7ab9ba0772ec83004f2fe9767aafc2596f07d78b6dd35ee2e9b47f3e4f9fd4c7c164feccda0a59cb87d",
         "dest": "nuget-sources",
-        "dest-filename": "cs-script.core.1.4.2-preview.nupkg"
+        "dest-filename": "avalonia.xaml.interactions.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/excss/4.1.4/excss.4.1.4.nupkg",
-        "sha512": "7de5ccf229c00c2d20a7c89bab3a9e2ff190c8dc67845098e4a49ce284a81b77a7dd6fe5736a69bfa638b72ae30c75e3b39a4c08ed8a8083f21bbdf5db059f33",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactions.custom/11.0.6/avalonia.xaml.interactions.custom.11.0.6.nupkg",
+        "sha512": "03fe107015f04015f833222ba252d1aa4abe57e1f5f9114466c45220a2eabc53a1a537303ff3a6a17455a2a1a7f3497add25647f392d84b80d4121a701181232",
         "dest": "nuget-sources",
-        "dest-filename": "excss.4.1.4.nupkg"
+        "dest-filename": "avalonia.xaml.interactions.custom.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/fizzler/1.2.1/fizzler.1.2.1.nupkg",
-        "sha512": "4a0fe8626c283acce7c7fe0406222a0195ad203515b2af297b0f9268646e54b860010eba96562ba2cf1e44deb1e903ddc81c26374cd6ca522318e36e94655520",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactions.draganddrop/11.0.6/avalonia.xaml.interactions.draganddrop.11.0.6.nupkg",
+        "sha512": "74cb5edfc57376480e3ee7e1914eb7aaa807d19eeef02c01b3c84abf605eea166bc514d9f481328cb5176fb3d6a6d7482dba4878dfbdae75f635bddfdf379fde",
         "dest": "nuget-sources",
-        "dest-filename": "fizzler.1.2.1.nupkg"
+        "dest-filename": "avalonia.xaml.interactions.draganddrop.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/2.8.2-preview.178/harfbuzzsharp.2.8.2-preview.178.nupkg",
-        "sha512": "a0c81fe7d6c81a2adc0b51a49f21e860fe4ba0dbcd291a0c05316667dc55561539b55f88fe22aef144d7dcbc369aa4492f525957d7420d00d5e194556ce13b8d",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactions.draggable/11.0.6/avalonia.xaml.interactions.draggable.11.0.6.nupkg",
+        "sha512": "7f00693ae9fea5ec05d9defa8947de5fc25dd3a58f19ef997807615558898713e3e74ff5618bc53d736efbad9c53151b9d8275609fe17f55f2a0f5bc4ae472b0",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.2.8.2-preview.178.nupkg"
+        "dest-filename": "avalonia.xaml.interactions.draggable.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/2.8.2.1-preview.1/harfbuzzsharp.2.8.2.1-preview.1.nupkg",
-        "sha512": "a7ade98e423293b73bfd39aca7e18ee7f928350ebeb7fbc9d0ed0820af174d075c7c367cf03677285ff6db36bd9a63257fd23b0ec416fa4992ca6f50c752b44b",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactions.events/11.0.6/avalonia.xaml.interactions.events.11.0.6.nupkg",
+        "sha512": "2e6fa3c1a23e2815a5d972625c6545e9737f1bb4e668b9bb554fafd9422ddf0a9fad53ccbc7c88620adf2e37e84d489f17ef286a7f395516cddaebbe722e4017",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.2.8.2.1-preview.1.nupkg"
+        "dest-filename": "avalonia.xaml.interactions.events.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/2.8.2.1-preview.108/harfbuzzsharp.2.8.2.1-preview.108.nupkg",
-        "sha512": "3de9e6ea186df99fd9a6d1d48908cc3d36ac9b7d1d16dfe5adef99b29d43eab6cd27b5ac85479d054b6cdc05cc92acdd981dfa1d46bfafedda3d83b28394cbe5",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactions.reactive/11.0.6/avalonia.xaml.interactions.reactive.11.0.6.nupkg",
+        "sha512": "77ce9677f2b71020fb7386a277559c07906d6e1b7ef4cba987a6e47b7c61c62c2dede50d8140d7102f1754e47facc32523ad17da31dcd3bf2d2e1ecf4898ba31",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.2.8.2.1-preview.108.nupkg"
+        "dest-filename": "avalonia.xaml.interactions.reactive.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/2.8.2-preview.178/harfbuzzsharp.nativeassets.linux.2.8.2-preview.178.nupkg",
-        "sha512": "d549c4494f7954f02a8667b2663be4b70bec42bc6ba6ba867ca0fab0e39ba2a83c2c7db03f7ab3c65ed7976e997a0f010519d6b25335c41d02defad809b3b8f7",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactions.responsive/11.0.6/avalonia.xaml.interactions.responsive.11.0.6.nupkg",
+        "sha512": "a43d7c00efc472ccfb1203d169c832ab828fcfa6d90d547ecaca1704481ac04b03e1a30a088466f7c31bc689ed55aaf58fc692c4ec854140002474549875de59",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.linux.2.8.2-preview.178.nupkg"
+        "dest-filename": "avalonia.xaml.interactions.responsive.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/2.8.2.1-preview.108/harfbuzzsharp.nativeassets.linux.2.8.2.1-preview.108.nupkg",
-        "sha512": "8935254107ec9580e920d810f4b5e9c2e2b6088bab7ccbd41a17b6da77a0b47b0be08f9d75d2c320b9b98c2753c00cb7955504786988d3254d3fdea18c46a3d8",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactivity/11.0.6/avalonia.xaml.interactivity.11.0.6.nupkg",
+        "sha512": "235cb134fe555e44a6802b15da1cc3c689fe613ab5d7a6901c6499603395ffb9edebb76ab35048d465f8c95d64bd70e500216394d91cbfa393f333bc85af5b6f",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.linux.2.8.2.1-preview.108.nupkg"
+        "dest-filename": "avalonia.xaml.interactivity.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/2.8.2-preview.178/harfbuzzsharp.nativeassets.macos.2.8.2-preview.178.nupkg",
-        "sha512": "587acc0a42eb40e0cffbb557bd048031b5cf4190c41831ce783a48159bbc32490274d0c19729fb6fd4c84a8c3094690fa34a24d38bbc48fd5015e70de0e9e4ec",
+        "url": "https://api.nuget.org/v3-flatcontainer/castle.core/5.0.0/castle.core.5.0.0.nupkg",
+        "sha512": "210328587ff705f78fa46a9e1bdc07c5a8110335122d533f604bde9382b6317677a3168cb4238a45483fc38bd3d2661738f6afaecc42d170b7ba778912cfa74e",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.macos.2.8.2-preview.178.nupkg"
+        "dest-filename": "castle.core.5.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/2.8.2.1-preview.1/harfbuzzsharp.nativeassets.macos.2.8.2.1-preview.1.nupkg",
-        "sha512": "567421cb185a7194b003f4bd8005146b2d0d4e298abb2e6118db109a0384e34f7e06023ed5dcf10dd393841aef51b53beb11997e33a0f06bbbfde1ed321c9ecd",
+        "url": "https://api.nuget.org/v3-flatcontainer/commandlineparser/2.9.2-ci-210/commandlineparser.2.9.2-ci-210.nupkg",
+        "sha512": "2aa0c5d45d93a80eedc507f0e1cde2c7fb996707ea16cbb695313ef1636e74b1a46aa6d55226690c5f1b1a2b33fa4c9d24f22ad0552daefbb28c102a5675ba17",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.macos.2.8.2.1-preview.1.nupkg"
+        "dest-filename": "commandlineparser.2.9.2-ci-210.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/2.8.2.1-preview.108/harfbuzzsharp.nativeassets.macos.2.8.2.1-preview.108.nupkg",
-        "sha512": "dde20e55f099d3de444d03d1a0da1fe074d8a074b32c43b8ba0e3a2d45fa66fb48b9db2c9a790183111634e3edbf67065a4501f036df9fbbd3fbf870db8c342f",
+        "url": "https://api.nuget.org/v3-flatcontainer/config.net/5.1.5/config.net.5.1.5.nupkg",
+        "sha512": "2c0eb61eee0ada0c92bb5f17e5643d61c880723f06554b08147de03e79bbd6d3e538ccb0006fb0ab28ba95db8e58e76ac92ed3d73c8d2bef7b07db27393022d4",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.macos.2.8.2.1-preview.108.nupkg"
+        "dest-filename": "config.net.5.1.5.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.webassembly/2.8.2-preview.178/harfbuzzsharp.nativeassets.webassembly.2.8.2-preview.178.nupkg",
-        "sha512": "4d1af17dbee025df0870ad9e61b05d5e4e0c173a0cc0f31fbcca22f0697dab1f9fea1579379869ef7a47d47da1e3642bdfa484565667998d05d50b42db93a2ac",
+        "url": "https://api.nuget.org/v3-flatcontainer/cs-script.core/2.0.0/cs-script.core.2.0.0.nupkg",
+        "sha512": "c9328cd6a189bacd21c69afb1657852dc9950e0532e2b6f5688e6eb09f96fd3fd3702f664e2506ac9288e3bcdc4cb57077657f2e49196600c46439183e703c34",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.webassembly.2.8.2-preview.178.nupkg"
+        "dest-filename": "cs-script.core.2.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.webassembly/2.8.2.1-preview.108/harfbuzzsharp.nativeassets.webassembly.2.8.2.1-preview.108.nupkg",
-        "sha512": "da78dd24556af8562b2ee4e53e49e7c17ba31f0a16e7b7a588371bdcf26a52af73fb60887253b6bc2e1e69dee94d38feb1730de0ad718753260120599b0ceee2",
+        "url": "https://api.nuget.org/v3-flatcontainer/excss/4.2.3/excss.4.2.3.nupkg",
+        "sha512": "fcb06d04937a6bd864060e8bdf4a65970c7450cdbdd3279465851310ac8bf12b645cac54ce8b7a8039c7ca9309ba3d9ee4e23827599479c4140f7755e119caa9",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.webassembly.2.8.2.1-preview.108.nupkg"
+        "dest-filename": "excss.4.2.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/2.8.2-preview.178/harfbuzzsharp.nativeassets.win32.2.8.2-preview.178.nupkg",
-        "sha512": "665318ba6d2fa1a4746e180ff3a122f19f7a175171a0bcf24bef0dd4a84f2f7fdfce7196bd7044b20051be2d074fe979e6e5eb1aeb7e76dbc8b8b6f3749307d0",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/2.8.2.3/harfbuzzsharp.2.8.2.3.nupkg",
+        "sha512": "44cdcfa570a075d28338f3b720ddc61c9eb3421ef14dabbcb751bd2103fb192d3fd0dff55ebac192db711c02b4d361bb652f55fa3e52c922110f3d3bacc8a173",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.win32.2.8.2-preview.178.nupkg"
+        "dest-filename": "harfbuzzsharp.2.8.2.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/2.8.2.1-preview.1/harfbuzzsharp.nativeassets.win32.2.8.2.1-preview.1.nupkg",
-        "sha512": "8fb5b9043626dbcb7a51e3f37d80f87a9ea4bb8eb9164297290d5d690d7394fb5fa7e462f1929e739c9f769ac499d348f6cbc10d34b28afee4ae6ca34e356441",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/7.3.0/harfbuzzsharp.7.3.0.nupkg",
+        "sha512": "5d1887b3cdc22334132f8fff8b2ac1f57cb54e9fcd25d21d32f8f86c7c694e86739c067e8b1ae3da10c1b1b3417f27b640b0e7890101ee2d420fba3feba580b5",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.win32.2.8.2.1-preview.1.nupkg"
+        "dest-filename": "harfbuzzsharp.7.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/2.8.2.1-preview.108/harfbuzzsharp.nativeassets.win32.2.8.2.1-preview.108.nupkg",
-        "sha512": "4ce79a68b383b466b690fcede1986103c2d88b99a92114e90ba32e07d802fe8436949272b4992bf366a0fbfa452699b9715532ab0ddb7746a3c4cc431a30a737",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/2.8.2.3/harfbuzzsharp.nativeassets.linux.2.8.2.3.nupkg",
+        "sha512": "fde70d49dc1e90c9ac171b643f6e3939071cb2197bc8101ede4c3ce7f1ab7581d945d4c91d103bc63243c017ec2688d791880e348c24908bb7651e983f0f0b13",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.win32.2.8.2.1-preview.108.nupkg"
+        "dest-filename": "harfbuzzsharp.nativeassets.linux.2.8.2.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/7.3.0/harfbuzzsharp.nativeassets.linux.7.3.0.nupkg",
+        "sha512": "48a4bf98b9f59181ef1885a3d4d3ee605b63aeab3b49248a3e49a6bbbdcdae4bcb974073492319789f17eb92edebc1ddf050c5d0724eddc5ea3277d5c2054731",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.linux.7.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/2.8.2.3/harfbuzzsharp.nativeassets.macos.2.8.2.3.nupkg",
+        "sha512": "6f371912b52eba613883bb1403f5d9be271662fb15f33fb27b332fa8a33cd0944ec86a24b8272f80ca82fbbf04287ac745aa245571a7bf49970db83a0d61376e",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.macos.2.8.2.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/7.3.0/harfbuzzsharp.nativeassets.macos.7.3.0.nupkg",
+        "sha512": "803ace4c95a3ae0c69e30003d3f6dc1b409ff0390b94c37d8dbc1a5321dca74b5d7b2a8aefaab0a792cd47d4e3c2d24e733ed313e0597d80a7ef81b67bc413ee",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.macos.7.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.webassembly/2.8.2.3/harfbuzzsharp.nativeassets.webassembly.2.8.2.3.nupkg",
+        "sha512": "9d0521518020b38f05b206c146102c8441b3f1c2ee604b26bb733382449bf45cc24d3a11320ebb3ccc396d86c64a5d1de37f0622a712f2a590c2c2ea2098e262",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.webassembly.2.8.2.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.webassembly/7.3.0/harfbuzzsharp.nativeassets.webassembly.7.3.0.nupkg",
+        "sha512": "eb0925b18271e435f1b90fabbefef4d01bf4d1443628509f66b4f4ecf8603bba91abac29b3b19a09170f491986c89d7a37d43f854d15379d9e74b27cbad6fae8",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.webassembly.7.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/2.8.2.3/harfbuzzsharp.nativeassets.win32.2.8.2.3.nupkg",
+        "sha512": "f51176b5bf944d8cee7b17269a43d43bd2297506ced8d16c87d3e8d421d68d71f85e8eb20982e5af902f53e20382709a9a0500140e5a74b758af35193f1bb771",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.win32.2.8.2.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/7.3.0/harfbuzzsharp.nativeassets.win32.7.3.0.nupkg",
+        "sha512": "3f477b5cb4d70df1333f69272c885c31dc43118ebf4edc990ae6ea8f29db0a3d4886a74b6d7ad2778d1db6bf7660bf0ae0eb23030c0b9c65710c5baa2389b00c",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.win32.7.3.0.nupkg"
     },
     {
         "type": "file",
@@ -260,13 +309,6 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/jetbrains.annotations/10.3.0/jetbrains.annotations.10.3.0.nupkg",
-        "sha512": "ad0c0fdda8d66adbb5da6c83b562df9c45b1cb7ec146c892747cbfdcf4409b1e9d620840378cceb2a94889d7e4d3cd4318347b736eca97e801e59d2dcfb78afc",
-        "dest": "nuget-sources",
-        "dest-filename": "jetbrains.annotations.10.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/libsodium/1.0.18/libsodium.1.0.18.nupkg",
         "sha512": "3c561728300bbb52b4cc191be11682edab3ee7e8713d8bf9931ca6ce88d280e1232160f2efcb0138ea2be84805ab4a6d2699edc2cf63a7cd28d81e0f2f5cf98e",
         "dest": "nuget-sources",
@@ -274,24 +316,24 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnet.webapi.client/5.2.7/microsoft.aspnet.webapi.client.5.2.7.nupkg",
-        "sha512": "4bc85f71e527cb90b4fb27f7075aba132ddfcac6c7e1ca3061a72723bb752c85f9de9154a6534bc3166098d2b61a4370fe113af10dc0cbedcd892d1e5724774a",
+        "url": "https://api.nuget.org/v3-flatcontainer/microcom.runtime/0.11.0/microcom.runtime.0.11.0.nupkg",
+        "sha512": "c00731176e34ea7b936ad58a38639843c790b027b714ed5d3ea828b85ea94b14a502ded52ca7f60bb10c0ac0e744bd6e62fdcce0108ebaaf9731c408eece031e",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnet.webapi.client.5.2.7.nupkg"
+        "dest-filename": "microcom.runtime.0.11.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/6.0.25/microsoft.aspnetcore.app.runtime.linux-arm64.6.0.25.nupkg",
-        "sha512": "8e747dc94ce413c8ce3c8ea6b3910e2ae9c81060e0fd73785675aff942bd10a99051236eb367f9f676badc3b8ef47051f60baa77388f8c5a9c87b7de1bc14b18",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnet.webapi.client/6.0.0/microsoft.aspnet.webapi.client.6.0.0.nupkg",
+        "sha512": "47d509834cca423ca9a6393ee4b6b7c56149d93dae96ac02b0712cd39bfd642969402a93a8cba924171e0103c915a3ab892e20a54e49943138f0509c1d51bccd",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-arm64.6.0.25.nupkg"
+        "dest-filename": "microsoft.aspnet.webapi.client.6.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.analyzers/2.9.6/microsoft.codeanalysis.analyzers.2.9.6.nupkg",
-        "sha512": "30b2d92add884d8bdc62a40605dd314b7ce9c80a23ae64962b6745b35c302a3868d237be4b27a292cacbd1b80cc6ecfb1cb444108c07750eff8f400fe3e13470",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/8.0.3/microsoft.aspnetcore.app.runtime.linux-arm64.8.0.3.nupkg",
+        "sha512": "28b09764aed05b097bbf7e03af5f05ab27ec992fc1476296f8c8d7d8e0f1bb6597594000e95cb8a4787019d4bd289b2a53b5c9a52ed224a8da94cf1d4b2ed694",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.analyzers.2.9.6.nupkg"
+        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-arm64.8.0.3.nupkg"
     },
     {
         "type": "file",
@@ -302,24 +344,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.common/3.4.0/microsoft.codeanalysis.common.3.4.0.nupkg",
-        "sha512": "652914ddc4c651c6c68265636c3c4bc76b9207b745387e57345db4d9c44b6346a6a267550db9c153cd2f3fc248bd4a69ee55b4da8a0e07285b09324792e466e5",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.common.3.4.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.common/3.6.0/microsoft.codeanalysis.common.3.6.0.nupkg",
         "sha512": "e17e766686185b48ec4357615fb296b70c19956cb57be3712fdad6984c6908b619001b7fe2a85b5d172e9254fa82eef8a06ddfa3f8cfc42079135bf5eee81d3b",
         "dest": "nuget-sources",
         "dest-filename": "microsoft.codeanalysis.common.3.6.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp/3.4.0/microsoft.codeanalysis.csharp.3.4.0.nupkg",
-        "sha512": "271ec0ee5949771958cd05b63bf2a879f97abcfe8275bb36a40ad22e4a700614115517820eaae752f05fe24c338efa06d8ae3f667b04c91c1db8d9be8a9749e1",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.csharp.3.4.0.nupkg"
     },
     {
         "type": "file",
@@ -330,24 +358,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp.scripting/3.4.0/microsoft.codeanalysis.csharp.scripting.3.4.0.nupkg",
-        "sha512": "c3ea6676face82f86a2ca46224f668e5516a233e5229cf4ed75f7172612ed675ae87e1ee3eb10fd7568dd641721a302b140ee6867c2bc9a102339400ba80340f",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.csharp.scripting.3.4.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp.scripting/3.6.0/microsoft.codeanalysis.csharp.scripting.3.6.0.nupkg",
         "sha512": "41a55829957cfd04a02dc2c64c3299aa4dbf3c8236cb079993e5e28884d08cf004f1e912e21f7adb73e76ca1f7be26638d339795f0a8ad0ceae7d20e9894ddd8",
         "dest": "nuget-sources",
         "dest-filename": "microsoft.codeanalysis.csharp.scripting.3.6.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.scripting.common/3.4.0/microsoft.codeanalysis.scripting.common.3.4.0.nupkg",
-        "sha512": "ad40179f4516a236ca01f65c4762d0420fff5738177dea5506eb5d66e0f431e52cf0e36a0777c4db8f5748e69ea506e54fb0dc0a5f0e28af2e7e6968020c73f5",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.scripting.common.3.4.0.nupkg"
     },
     {
         "type": "file",
@@ -372,17 +386,17 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.linux-arm64/6.0.25/microsoft.netcore.app.host.linux-arm64.6.0.25.nupkg",
-        "sha512": "ca3c85e36c1170633102b8ace1cebfff88922182f821d237dac68be4656d52bb3ff0e183f51c81c966de96351430f7b169ffa04a8119883171e380b5845a3c58",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.linux-arm64/8.0.3/microsoft.netcore.app.host.linux-arm64.8.0.3.nupkg",
+        "sha512": "80acf9344e71a3da6bba87b52b6a519ad0b14d5de3d57ea78517cd99830f936e6e64924c9578631381ee65ecf4f29e13d38cff5c6b9642ef0f48538855751483",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.host.linux-arm64.6.0.25.nupkg"
+        "dest-filename": "microsoft.netcore.app.host.linux-arm64.8.0.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/6.0.25/microsoft.netcore.app.runtime.linux-arm64.6.0.25.nupkg",
-        "sha512": "5591df69ffbaab9fcc455bebdba77ac47753782e9290f103d441d225d83c6634f926bae6ba9dea2fef99dff2b482beecb455c55518f4390ebca71bb8f528cee6",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/8.0.3/microsoft.netcore.app.runtime.linux-arm64.8.0.3.nupkg",
+        "sha512": "7d26f1f2ff543b73428596f522fac00613aaeb2e195882e5ae3841a51abcf514f9c7659b958cdf63ba4722f93b0a73fff26378f39ed5ca52077b5638b273fb94",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.linux-arm64.6.0.25.nupkg"
+        "dest-filename": "microsoft.netcore.app.runtime.linux-arm64.8.0.3.nupkg"
     },
     {
         "type": "file",
@@ -400,31 +414,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/2.0.0/microsoft.netcore.platforms.2.0.0.nupkg",
-        "sha512": "0827f83639833a88ac7bb1408a3d953ee1c880a2acbbaf7abe44f084e90f5507cbb13981d962c57d0e3278ee5476d93c143eb7e9404cc7a63d7a8bf324a4fbe8",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.platforms.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/3.1.0/microsoft.netcore.platforms.3.1.0.nupkg",
-        "sha512": "636a1e3768f782ced193b18ec61616c122b5b756395bbec3ede805b172ce62db2d631407deebba73bf136234479be4824f0268a57f52ff4f8d7d37d4370cd966",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.platforms.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/5.0.0/microsoft.netcore.platforms.5.0.0.nupkg",
         "sha512": "8493fe11648c7ecc20b6530490d30fd63744961345c0501a7a10b11046661da09b783ddceb8b3208ae52a72a8a94cafdce8dc1bd6073c32081e30d0e7407f174",
         "dest": "nuget-sources",
         "dest-filename": "microsoft.netcore.platforms.5.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.0.1/microsoft.netcore.targets.1.0.1.nupkg",
-        "sha512": "6ed8e75f945a18651066fe9ee31cf6c8257a5974340fe4d262438903c4959a479f4a515a4d1389e6d3d3ab34f09a3c7bc2009aada2e8a7f697b6655a82d3bfc9",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.targets.1.0.1.nupkg"
     },
     {
         "type": "file",
@@ -435,13 +428,6 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.primitives/4.3.0/microsoft.win32.primitives.4.3.0.nupkg",
-        "sha512": "366f07a79d72f6d61c2b7c43eaa938dd68dfb6b83599d1f6e02089b136fa82bec74b6d54d6e03e08a3c612d51c5596e3535cbc2b29f39b97a827b3e7c79826f0",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.win32.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.registry/5.0.0/microsoft.win32.registry.5.0.0.nupkg",
         "sha512": "471e66567ce59cc86475aece7815d05261264ce114e0c1688ba2551dd51494901fa72dd7a8f74f8e8f0f3dba74af8595f177552f3c06abb4bfce76692197076e",
         "dest": "nuget-sources",
@@ -449,17 +435,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.systemevents/4.5.0/microsoft.win32.systemevents.4.5.0.nupkg",
-        "sha512": "2b64c0af4ee9825fe6fc9f5e777726033c74483e79918b957c11ba48f4481ff10b4e1fc3daa1ab8ce583409a3bafe2d99759ced8d925d14010054b7a4b67b0a9",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.systemevents/6.0.0/microsoft.win32.systemevents.6.0.0.nupkg",
+        "sha512": "5e274ace996c3eba63099ed5116f9dc39f69f684f7c1e7623c28c3c73988b75c67dfcc929a50a761f0222df243dd540720a6e588e91dfa784f81bfce7a893875",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.win32.systemevents.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.systemevents/4.7.0/microsoft.win32.systemevents.4.7.0.nupkg",
-        "sha512": "3dc95211fd597cbeb7b8498e79d58c8dc373767d129252f1858f223fe9228bef56c4dd48e613694581fd197e8c1ec428ec8788a451b9c248e2073c7603c994d4",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.win32.systemevents.4.7.0.nupkg"
+        "dest-filename": "microsoft.win32.systemevents.6.0.0.nupkg"
     },
     {
         "type": "file",
@@ -470,31 +449,17 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/netstandard.library/1.6.1/netstandard.library.1.6.1.nupkg",
-        "sha512": "0972dc2dbb4925e896f62bce2e59d4e48639320ee38ad3016dcd485fbd6936a0ed08073ad5eef2a612dff05dfc390f3930fff9e79d87a06070eeb8128277cbd0",
+        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg",
+        "sha512": "83731b662eaf05379a23f8446ef47bbc111349dd4358b7bd8b51383fe9cf637e2fe62f78cea52a0d7bdd582dc6fbbb5837d4a7b1d53dcf37a0ae7473e21ee7b1",
         "dest": "nuget-sources",
-        "dest-filename": "netstandard.library.1.6.1.nupkg"
+        "dest-filename": "newtonsoft.json.13.0.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/10.0.1/newtonsoft.json.10.0.1.nupkg",
-        "sha512": "30e52141f788e37ba9abd42212ffbb6184c340fb446448fdc41e74320a653b55c5fdaba63f47fe4c26081e964499fb226a1249697b7f81d44560b144a05d95c9",
+        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json.bson/1.0.2/newtonsoft.json.bson.1.0.2.nupkg",
+        "sha512": "339d937e19fc2b3b1f99328797dfca8d51ef03acd6c6e61ae3a1d9de576a953e14dcdfe911e1efc2dcb3631fb7fe35672dbe2deb6841db358d5700c69745477e",
         "dest": "nuget-sources",
-        "dest-filename": "newtonsoft.json.10.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.3/newtonsoft.json.12.0.3.nupkg",
-        "sha512": "6934665f0479c58bbe996c44f2bf16d435a72f4d92795f0bc1d40cb0bc1358ff0e660ac20b24eabce01ee6145bd553506178e59fbaabd0f2a94b23bfa5c735f5",
-        "dest": "nuget-sources",
-        "dest-filename": "newtonsoft.json.12.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json.bson/1.0.1/newtonsoft.json.bson.1.0.1.nupkg",
-        "sha512": "5b929ee717a2f724b4963419b93ef95604a9e4ce377823e6e611c07a5bcac86194e1d57b8580a6b7076cc680036ff7b13baa581debbf2248b8dd37583f37c449",
-        "dest": "nuget-sources",
-        "dest-filename": "newtonsoft.json.bson.1.0.1.nupkg"
+        "dest-filename": "newtonsoft.json.bson.1.0.2.nupkg"
     },
     {
         "type": "file",
@@ -519,31 +484,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.diagnostics.tools/4.3.0/runtime.any.system.diagnostics.tools.4.3.0.nupkg",
-        "sha512": "bd257401e179d4b836a4a2f7236a0e303ae997d2453c946bf272036620a0b14e85e5f42c229332930a954655ab4cae359d191a3e3d9746df09535a651367764c",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.diagnostics.tools.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.diagnostics.tracing/4.3.0/runtime.any.system.diagnostics.tracing.4.3.0.nupkg",
-        "sha512": "0b480d21e23c38965222be7fa1e1a0c7e444cebdf400d1db8d3ac609f893b82d78c5d8b271da61808b7b179dd6466a0090bd807fc2d35020f93a00f0213bb436",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.diagnostics.tracing.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization/4.3.0/runtime.any.system.globalization.4.3.0.nupkg",
         "sha512": "3aac1a076212fae7d0ac81d2b5fdf216b064a1d890577307f89c9a4984c239838c3bdfac4dea052027de090704839319231eef49ce542f3e8bb2f85ba23d28dc",
         "dest": "nuget-sources",
         "dest-filename": "runtime.any.system.globalization.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization.calendars/4.3.0/runtime.any.system.globalization.calendars.4.3.0.nupkg",
-        "sha512": "19053b502b7160af6f6b0bc5b334a8d124f77f6b4418993294fb485d0bb318cd6e97cdbda9bf8c9927366288413cad7209c9d8156a5425a6320c453a8804fb3d",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.globalization.calendars.4.3.0.nupkg"
     },
     {
         "type": "file",
@@ -610,24 +554,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.text.encoding.extensions/4.3.0/runtime.any.system.text.encoding.extensions.4.3.0.nupkg",
-        "sha512": "656aa8bd9d7e19534964ac7b8405615f00359779e322d4cfe1f18c132fec4a4f52c5588bfe61cec9966a9142a73315f5d2b9e5a7c524b418364f0322b20961c3",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.text.encoding.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.threading.tasks/4.3.0/runtime.any.system.threading.tasks.4.3.0.nupkg",
         "sha512": "5f37a56f5d6c7fc198c7ef76b822b85284f9d7d1c06583c26a698793ade65da1b273d5fb03c20be1eb91a9c835f7122ad2775f4e51dffb2758fabac2a30f8c23",
         "dest": "nuget-sources",
         "dest-filename": "runtime.any.system.threading.tasks.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.threading.timer/4.3.0/runtime.any.system.threading.timer.4.3.0.nupkg",
-        "sha512": "c0a1fc3661b4e21f329f88a8d2cbf7152698427778add9f850476fc9abe7cdf9b86df79362d6df025f7e15d53f5eb7937d8ac49bdef13fd9eca973a284929fcf",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.threading.timer.4.3.0.nupkg"
     },
     {
         "type": "file",
@@ -659,27 +589,6 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.io.compression/4.3.0/runtime.native.system.io.compression.4.3.0.nupkg",
-        "sha512": "bff1f0cac94327014bb07c1ebee06c216e6e4951b1ddaa0c8a753a4a0338be621fd15ec621503490dbca54a75809abc4f420669b33052b28d24d726ac79c9891",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.native.system.io.compression.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.net.http/4.3.0/runtime.native.system.net.http.4.3.0.nupkg",
-        "sha512": "ddd1e5b67545477f7c72b5883666de40e89efb0836d91e7a349e2f3d4ac05ce1125e6add3cb09c39cbdfe7ab7c5dc8fdaeaf6ac25acd92f6de3d8ce2d6db7918",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.native.system.net.http.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.apple/4.3.0/runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
-        "sha512": "23c6a99b323cd71cdcb28c6faa71f099f69ff0972d5125607ae8bbc99ba7c08513571d14526e8c2805ab3a8b70d3d3a6dd76dfa193320393ecb05906ee91f37d",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.openssl/4.3.0/runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
         "sha512": "ee5d047908b99b776ff9bb54856454b24b09a0f9271b127239543b1f5faa3381a032d9eeb4d813d01b5a4b7d183b6a16250f159fdc450d5314a7eace1550bea3",
         "dest": "nuget-sources",
@@ -698,13 +607,6 @@
         "sha512": "6de9544b4da49f127680cf5b3b4afea96bfcac3293038a1b0a12eea0ad60be368af31ee1dfd66d48d458b40200738c04aa0c71adcc54ae2dddbea2cd50d6f28d",
         "dest": "nuget-sources",
         "dest-filename": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.0/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
-        "sha512": "9929942914071e0ea0944a952ff9ad3c296be39e719a2f4bb3eac298d41829b4468b332fba880ebe242871a02145e1c26dc7660021375d12c7efcae4d200278a",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
     },
     {
         "type": "file",
@@ -743,45 +645,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.microsoft.win32.primitives/4.3.0/runtime.unix.microsoft.win32.primitives.4.3.0.nupkg",
-        "sha512": "93e6d3db61f9c2ca2048f25990dda92acd5ec74561e0c776d2c6dd8d1d55128f2c953f33d6832fb6a72bd9edca304a2551085bdeafe6e18af87619c9ba943c32",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.microsoft.win32.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.console/4.3.0/runtime.unix.system.console.4.3.0.nupkg",
-        "sha512": "7c5cbda7d12315fff6b1e036d55ea27140de8b849f1a9705fd2710a00a2b70f06f534eb0d3e3c8ffb019e1a47d96c559ac61d5fc9d840e48f6e56542fdaccb83",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.console.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.diagnostics.debug/4.3.0/runtime.unix.system.diagnostics.debug.4.3.0.nupkg",
         "sha512": "a8ce331953b1f4424aa7f4b6dfedfce9ad138940bc92f332de2bc6d05185830ec6eb832e752f62eaf425f749caadd4ea1789121cb7ed79740fa5868eba55c838",
         "dest": "nuget-sources",
         "dest-filename": "runtime.unix.system.diagnostics.debug.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.io.filesystem/4.3.0/runtime.unix.system.io.filesystem.4.3.0.nupkg",
-        "sha512": "6d4c80aceffac60e1560fda34c5984bbfa2e1bd106bde2c6d3540905cc30c58e6f5f2eaf5703cef5e68e3d25a4b97982193b2db8130a50c622a498e43eb9bdca",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.io.filesystem.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.net.primitives/4.3.0/runtime.unix.system.net.primitives.4.3.0.nupkg",
-        "sha512": "c2a0ecf5c72b226b4776eb6281f00267827d6086a0ad758ebf6e6c64a1c148d2056fe99c87ab4207add5fa67f1db73dd1ed3dca81141fc896be6b6e98795c97e",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.net.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.net.sockets/4.3.0/runtime.unix.system.net.sockets.4.3.0.nupkg",
-        "sha512": "31b62be088315ead04d89f452a6c49a656b88f0668f7dadb2790511675d48705e01c9df24dbed3a0095157875c208ab6e6b5b6afc82bac13e4d6cdd3026f8424",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.net.sockets.4.3.0.nupkg"
     },
     {
         "type": "file",
@@ -813,24 +680,17 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog/2.10.0/serilog.2.10.0.nupkg",
-        "sha512": "9c19964d1126c2e99f546f1da81764644fe39b153e3d8d725473221a6e0855f356776d2f40a8a5d04ece4e420075d5b987650108a4fc9b32b4f56ad3d0792260",
+        "url": "https://api.nuget.org/v3-flatcontainer/serilog/3.1.1/serilog.3.1.1.nupkg",
+        "sha512": "02985d43db0efd5e56b086e0a29af986de381a163a8633ab81a88b6620a3df380afc4506366beba0f214ac8ec37c8d435bdf130285dcde331b14733e62fab8c7",
         "dest": "nuget-sources",
-        "dest-filename": "serilog.2.10.0.nupkg"
+        "dest-filename": "serilog.3.1.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog/2.11.0-dev-01367/serilog.2.11.0-dev-01367.nupkg",
-        "sha512": "c89dc8498316f387d822f45feef27a08605b2f5df17138b8f670c8c3a430781ee1933cc5e74bacdc698a7049d7bd21e53fbdd6cba42914da55d19c6d16a7156e",
+        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.console/5.0.1/serilog.sinks.console.5.0.1.nupkg",
+        "sha512": "8f7ab152456edd504e8fce061be144c0c8694f76eb6f61a0284541f23e88a8c292cab487496bb64ce4faec926b53d3923a31cf3ddc874fd9b26f02089a53bb5b",
         "dest": "nuget-sources",
-        "dest-filename": "serilog.2.11.0-dev-01367.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.console/4.0.1-dev-00876/serilog.sinks.console.4.0.1-dev-00876.nupkg",
-        "sha512": "4116f4f58c28a34b39521251f4e044041780219b9676945fbbec474e15d482979fadc12f216cc1dbab17815bdae146bb1e30e96d6fbb8d05516923c6882764f1",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.sinks.console.4.0.1-dev-00876.nupkg"
+        "dest-filename": "serilog.sinks.console.5.0.1.nupkg"
     },
     {
         "type": "file",
@@ -855,122 +715,115 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/shimskiasharp/0.5.16/shimskiasharp.0.5.16.nupkg",
-        "sha512": "bed64051cbbd747cea734d7ad9a430a34a202ac1514d520b898b4147b25fb42f980793722b10c122e68e903f67270ed02c424a694bcca37acfa9fa4b4a499f40",
+        "url": "https://api.nuget.org/v3-flatcontainer/sharphook/5.2.3/sharphook.5.2.3.nupkg",
+        "sha512": "51ca1609dbbf67a2c89dcf3756d8fe0fad54847617506fcc5eaf4f42d4a3f3b24d56c7f3989aacf2260df2e2ee34d0f76d4ebb40eca47ae33a52b5904c0befdf",
         "dest": "nuget-sources",
-        "dest-filename": "shimskiasharp.0.5.16.nupkg"
+        "dest-filename": "sharphook.5.2.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/2.88.1-preview.1/skiasharp.2.88.1-preview.1.nupkg",
-        "sha512": "2af130252fc54b5adc8bbbe558d042fe5c86ca881184865c747fc365c9c557a4ac338c5f4a529ba440ea4fe38e38f754109a5a89cb1ef78392fb3ea3f8203b63",
+        "url": "https://api.nuget.org/v3-flatcontainer/shimskiasharp/1.0.0.13/shimskiasharp.1.0.0.13.nupkg",
+        "sha512": "705bfd34f50270bdc3f6fabca07f7860887cd2da9f3a65bfa29a76bf51773d00110f0f4e953e0eed3fcef63073b5430ef92a90ea0d3d33573853811c333ee466",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.2.88.1-preview.1.nupkg"
+        "dest-filename": "shimskiasharp.1.0.0.13.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/2.88.1-preview.108/skiasharp.2.88.1-preview.108.nupkg",
-        "sha512": "4e283d7b377c8bc6bfd1295fe9e977169447b870a994102f7d24b08b176846a0ca7f01539d75b84c5a8d7a545cd627c838b8194e0c4cd1e5a868396acf1a3483",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/2.88.6/skiasharp.2.88.6.nupkg",
+        "sha512": "5b989f52d9e7efa557bf60e13c1ba329b63670bc66d07bf237e2c8f9bdf28634eeb1e3a735c17c0f7d5b6cb8e290bda0b139540a8b0b99343367f9710f81dffd",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.2.88.1-preview.108.nupkg"
+        "dest-filename": "skiasharp.2.88.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.harfbuzz/2.88.1-preview.1/skiasharp.harfbuzz.2.88.1-preview.1.nupkg",
-        "sha512": "c9286331f2b32cb73e2000f544f66fb4e28a004cd92b486127c7aa2e77adfdbe59a0cc109f8cefab0950c812ddf15b2df34e1c56b59f5673c1a520e070b4db04",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/2.88.7/skiasharp.2.88.7.nupkg",
+        "sha512": "4a54db99f245742231c208c455b6f29a96ee79672e3eab7f7dbd6b352aeaa3b6a87d6946017d899887b4026d5b4ceca6297230dbaacf1725a9726f796ee72303",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.harfbuzz.2.88.1-preview.1.nupkg"
+        "dest-filename": "skiasharp.2.88.7.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/2.88.1-preview.1/skiasharp.nativeassets.linux.2.88.1-preview.1.nupkg",
-        "sha512": "6153cd7b79775918e912da027e0829f1c1b71e2a0067d7731008bad71819c969d5e7fb3b59fe553cc556fa4c6ca6655c7bb1ec5a4872152083e925f04845c1ba",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.harfbuzz/2.88.6/skiasharp.harfbuzz.2.88.6.nupkg",
+        "sha512": "9f8b6448ee3a24af51fac0aaf5a55f5824e40068a1bc2a1a9f1ae646f8b672f9ab22a2e1a306284f01c496fe05e1a3c7e0657a17d02e07ae042c132fb2a3edd7",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.linux.2.88.1-preview.1.nupkg"
+        "dest-filename": "skiasharp.harfbuzz.2.88.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/2.88.1-preview.108/skiasharp.nativeassets.linux.2.88.1-preview.108.nupkg",
-        "sha512": "e60ed0a574bb1d76057b1ec7c71d223a1e8c4d7722095979d9f3cef7706b8a084b302aeb5bb81c79f5daaf886ad48b229e0826388353abefd0b45487a18bb48b",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/2.88.3/skiasharp.nativeassets.linux.2.88.3.nupkg",
+        "sha512": "544ef5b9e0a9d97214e743a93b0147364a767e5a31374dfb8dcd069f14a424b54db56fce85f28d14157b7493930d7408f99afbc383994cd2243e9bb27bf57813",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.linux.2.88.1-preview.108.nupkg"
+        "dest-filename": "skiasharp.nativeassets.linux.2.88.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/2.88.1-preview.1/skiasharp.nativeassets.macos.2.88.1-preview.1.nupkg",
-        "sha512": "0e70fd1833f43b72ed69106d54e449ef71ecc2ad7079b6c6403a3d2d5d979191f77ba340dc9b577cdf88f51e4f31232bf42dfd645a9a5cd110732504c568228c",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/2.88.7/skiasharp.nativeassets.linux.2.88.7.nupkg",
+        "sha512": "4f7db81ee10c07db2d824813dacf0189bafd0e30dcb3087ffebfab9927976f67c2cde71c1a22345718d83fa32193303cf9d578e7d9d6fa30964ca1bf8c8127d7",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.macos.2.88.1-preview.1.nupkg"
+        "dest-filename": "skiasharp.nativeassets.linux.2.88.7.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/2.88.1-preview.108/skiasharp.nativeassets.macos.2.88.1-preview.108.nupkg",
-        "sha512": "0ba49dc28fca165f60a842ce7323b773b52847ff4c1af054a3da74892b7132246fe2dfdacc2527d044522712c20d8bdf4b158128d88f9b9156a677eb60375e5e",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/2.88.6/skiasharp.nativeassets.macos.2.88.6.nupkg",
+        "sha512": "a9abf36aadd48c8a9e0ea35f95acdbe3a354091b37f97c1df97499213894f662e798687bad36da71fcfa05b6fdbc68aaff2e8a8ddbeec4ca2820bfe7cf5a9ed7",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.macos.2.88.1-preview.108.nupkg"
+        "dest-filename": "skiasharp.nativeassets.macos.2.88.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.webassembly/2.88.1-preview.1/skiasharp.nativeassets.webassembly.2.88.1-preview.1.nupkg",
-        "sha512": "8219d9ea3f2fea1daf62c3dd0d172ce9a121b609648a77d1142234c6bc8eef6fffef285ce7c8c8688e3d114aa3580309939796aea298be1ef5ba384474cc18dc",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/2.88.7/skiasharp.nativeassets.macos.2.88.7.nupkg",
+        "sha512": "52ce6db283f366aa8f469f80564586c4d09fdbdbc4442fe24bf159fca803b92bdf2e209f537f9b30948a289e063fced46232b44a5c686168e33322e6314f1d5e",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.webassembly.2.88.1-preview.1.nupkg"
+        "dest-filename": "skiasharp.nativeassets.macos.2.88.7.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.webassembly/2.88.1-preview.108/skiasharp.nativeassets.webassembly.2.88.1-preview.108.nupkg",
-        "sha512": "10adc0bb36530b690c784407524ef5f6298dbd5a21fc32beb7be0fd4004905e2d775bd1edde55b7efbfd6a97bbf7660175ed6ca7fbf1ae8ecea008fd8bb4bde7",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.webassembly/2.88.3/skiasharp.nativeassets.webassembly.2.88.3.nupkg",
+        "sha512": "243ef57a09f88cfa086acd74419ba7c39b041cd113d4de2e72192ca8a40d7ecc74b5ab60f6a80195b89b7dff249650d48f44cbd25450b264cde79a7034600faa",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.webassembly.2.88.1-preview.108.nupkg"
+        "dest-filename": "skiasharp.nativeassets.webassembly.2.88.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/2.88.1-preview.1/skiasharp.nativeassets.win32.2.88.1-preview.1.nupkg",
-        "sha512": "91e2291dded613cbdf3242ba48a728aba1f1d8e428536b974ddd1ba96950431116c83fe20138244af6e86e40a783d67c1784ec270c155d9af3a2024ae25d4b10",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.webassembly/2.88.7/skiasharp.nativeassets.webassembly.2.88.7.nupkg",
+        "sha512": "bee40d258b80a0ea1e849d77c8fd7d594643ac24c666aa9575473462009cdfd1c33e1d4148848187bebc239ced3eb37652b3c7558a597c6959604aabf44498a4",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.win32.2.88.1-preview.1.nupkg"
+        "dest-filename": "skiasharp.nativeassets.webassembly.2.88.7.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/2.88.1-preview.108/skiasharp.nativeassets.win32.2.88.1-preview.108.nupkg",
-        "sha512": "46a101fb62e66a43c81bc69ee073ccaeab38e0ef764806f03b7812dbd6364dd1433752518a44d6adef100190b959a29462f5b60a258243d40994a25fc56b8607",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/2.88.6/skiasharp.nativeassets.win32.2.88.6.nupkg",
+        "sha512": "02087547abd840806105270d43cc3a61b417f331192498571e2cff1382dfd15a1bf6b1552610c7579bf06da69b6e9a80b042ae980d0475da8acf3f7dab7334f4",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.win32.2.88.1-preview.108.nupkg"
+        "dest-filename": "skiasharp.nativeassets.win32.2.88.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/svg.custom/0.5.16/svg.custom.0.5.16.nupkg",
-        "sha512": "002cb9e5d13a0d69c2cd8b36161a5d6173fcfc177739751c381eaae15a5f00834e4e6047f6af379a2a22b14fd75783449293f0da9031b1b27a0f0541a5db334a",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/2.88.7/skiasharp.nativeassets.win32.2.88.7.nupkg",
+        "sha512": "3476a2b19745b1ece35858a8534a02f7196ea0b30971d96b4d6219d2e8de4068f9ad83b5e0527519facd88fc64b46c69ac43b45a0f26c01e36885c3c54872324",
         "dest": "nuget-sources",
-        "dest-filename": "svg.custom.0.5.16.nupkg"
+        "dest-filename": "skiasharp.nativeassets.win32.2.88.7.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/svg.model/0.5.16/svg.model.0.5.16.nupkg",
-        "sha512": "a05c6d960736459751b0045f7a4ab0a3f6f4da4b7bd5f249b158157a4279bb3d56532d951b4be72df7859909f0344c827a2f9456b0894b73437408e44f9e57b5",
+        "url": "https://api.nuget.org/v3-flatcontainer/svg.custom/1.0.0.13/svg.custom.1.0.0.13.nupkg",
+        "sha512": "45343585e56c4d72c3be8219184f5cdd13ec5b79fdecd3ba2bd3850d131e9adacf4de798d5782fadf88b468e98635e4bcb7f7a0320092a10d1d46698a51793f3",
         "dest": "nuget-sources",
-        "dest-filename": "svg.model.0.5.16.nupkg"
+        "dest-filename": "svg.custom.1.0.0.13.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/svg.skia/0.5.16/svg.skia.0.5.16.nupkg",
-        "sha512": "6a26a29418a4ea236302c28d199ab4a1478a2ec22031390a57faecd4dea5369a1767c723ad2e0bfffb684c642447d59c23a218d9443f51dae187e14525bfa93d",
+        "url": "https://api.nuget.org/v3-flatcontainer/svg.model/1.0.0.13/svg.model.1.0.0.13.nupkg",
+        "sha512": "680a4103bc1763c59b0095d80b3171628746d1b7eee9baec16345d80af863750852532b24e0c410dbaa2a68a3402dfc5fcca766c5980786e66b646a7358f0877",
         "dest": "nuget-sources",
-        "dest-filename": "svg.skia.0.5.16.nupkg"
+        "dest-filename": "svg.model.1.0.0.13.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.appcontext/4.3.0/system.appcontext.4.3.0.nupkg",
-        "sha512": "0d6ea63006304708feae2cc0590d2cdd99327b682210822bb2803ac842fdf4d8d57170d7947c006eec4b5687c942768478a7ec109745472f3946d230732483e8",
+        "url": "https://api.nuget.org/v3-flatcontainer/svg.skia/1.0.0.13/svg.skia.1.0.0.13.nupkg",
+        "sha512": "da109cb14d434aced99957b207c9adca01a7b91eab43a109ddf1690df273e848e34d289e7a96d6e5f5bfcb1ae694709b27a4fa99da0ecf1fb649a5ef1e7428bf",
         "dest": "nuget-sources",
-        "dest-filename": "system.appcontext.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.buffers/4.3.0/system.buffers.4.3.0.nupkg",
-        "sha512": "3dcbf66f6edf7e9bb4f698cddcf81b9d059811d84e05c7ac618b2640efed642f089b0ef84c927c5f58feffe43bb96a6bcf4fec422529b82998b18d70e4648cbe",
-        "dest": "nuget-sources",
-        "dest-filename": "system.buffers.4.3.0.nupkg"
+        "dest-filename": "svg.skia.1.0.0.13.nupkg"
     },
     {
         "type": "file",
@@ -981,13 +834,6 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.concurrent/4.3.0/system.collections.concurrent.4.3.0.nupkg",
-        "sha512": "35c1aa3e636216fe5dc2ebeb504293e69ad6355d26e22453af060af94d8279faa93bdcfe127aecb0b316c7e7d9185bcac72e994984efdb7f2d8515f1f55cf682",
-        "dest": "nuget-sources",
-        "dest-filename": "system.collections.concurrent.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.collections.immutable/1.5.0/system.collections.immutable.1.5.0.nupkg",
         "sha512": "4f95c64257078443bbe50c77f061825033dd9389ffef2ad1993832e32733cc957c6a53c76b13d4e794c10b6505ae4438d9bbb7e2c64f7cad1d53e9d665438424",
         "dest": "nuget-sources",
@@ -995,59 +841,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.nongeneric/4.3.0/system.collections.nongeneric.4.3.0.nupkg",
-        "sha512": "dc6abfe778b3ea08e99f50b79112a51728e689f353b082234351b9f5b1be4b601a0b6d38a04c2138d05b5bdd83d6f3d91b53ee86ed119225c15e4683c38bf98c",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.configuration.configurationmanager/6.0.0/system.configuration.configurationmanager.6.0.0.nupkg",
+        "sha512": "de58cb928d6303a16301fd7aa8edac379dfe6c47e6d80b21665f92bab9dd5ff52b3e244cf6df0f945f1c72e71c92337561dbf2752fc3324174a8c9ecc70c3247",
         "dest": "nuget-sources",
-        "dest-filename": "system.collections.nongeneric.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.specialized/4.3.0/system.collections.specialized.4.3.0.nupkg",
-        "sha512": "c7a257cbda812d6c0c44b29d8bb5cc4f5cf2d3cb81574eb1dc94a7efde980ac26c5ffadb7cc3521fe7b19437766a046c83cbf2e7ea59a36435c288add8142b57",
-        "dest": "nuget-sources",
-        "dest-filename": "system.collections.specialized.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.componentmodel/4.3.0/system.componentmodel.4.3.0.nupkg",
-        "sha512": "7c638ac92a132e1553a089c6a711ffb7431b22fecca322ce748d6684ae2baaf161bab2f71704750bd15ec6fda11e795f2ab8491ac769b89341bde77aa9212d59",
-        "dest": "nuget-sources",
-        "dest-filename": "system.componentmodel.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.componentmodel.annotations/4.5.0/system.componentmodel.annotations.4.5.0.nupkg",
-        "sha512": "7f5029507196abf9490bc3d913b26a6c0ded898ed99e06503b699b61f086d0995055552aaa654c032d1f32f03012e1badfd338ec42dd3fa3d0c5ce4e228ea2e8",
-        "dest": "nuget-sources",
-        "dest-filename": "system.componentmodel.annotations.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.componentmodel.primitives/4.3.0/system.componentmodel.primitives.4.3.0.nupkg",
-        "sha512": "ab26d413abce9cfc31b860765d91b21d4048976016d853ce8969f7ba79c039d8846b3c4e2986530f20b62dcb23ff0a769ae5ee37fc078d69eaa962832f2035ef",
-        "dest": "nuget-sources",
-        "dest-filename": "system.componentmodel.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.componentmodel.typeconverter/4.3.0/system.componentmodel.typeconverter.4.3.0.nupkg",
-        "sha512": "0a2b2f3c25de4a6429c6cb9fbb37409e86168921ea71ec58889912742e39e1b67f5cbe764affc3580aa0ef167c7f73a55332a0abf7b043e89185293029d8b087",
-        "dest": "nuget-sources",
-        "dest-filename": "system.componentmodel.typeconverter.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.configuration.configurationmanager/4.7.0/system.configuration.configurationmanager.4.7.0.nupkg",
-        "sha512": "0047bbc7777fa368f0a6f352bf994b44bccb1bef81ef7037065eb976977cffe99e6c964407a7d30961f3a8213dd52cf44a81f47b6fc7d698ea5d54444618f6af",
-        "dest": "nuget-sources",
-        "dest-filename": "system.configuration.configurationmanager.4.7.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.console/4.3.0/system.console.4.3.0.nupkg",
-        "sha512": "a08a684a583c9b3278ce32be1007dae495f9d87254666392f794ef1203079f333cd7d388c28944ffa36fb49f0c8bb21f42c70f6e1d7c1c03920df6d0d1130c82",
-        "dest": "nuget-sources",
-        "dest-filename": "system.console.4.3.0.nupkg"
+        "dest-filename": "system.configuration.configurationmanager.6.0.0.nupkg"
     },
     {
         "type": "file",
@@ -1058,45 +855,17 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/4.3.0/system.diagnostics.diagnosticsource.4.3.0.nupkg",
-        "sha512": "8f54df5ff382b6650e2e10d1043863a24bf49ff0714e779e837cd7073e46fb2635bcfcdcf99d7c4a9d95f35ebffd86ab0ca068305f4b245072e08303b917b34d",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.eventlog/6.0.0/system.diagnostics.eventlog.6.0.0.nupkg",
+        "sha512": "40103d5b7cb2b41c7cafca629c112c5526bb773d11367ca62918d8864fba8dac2b48151f37671bcf50499d8f8b268489ee1cade2fb8947cc06e205a1fac6784c",
         "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.diagnosticsource.4.3.0.nupkg"
+        "dest-filename": "system.diagnostics.eventlog.6.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tools/4.3.0/system.diagnostics.tools.4.3.0.nupkg",
-        "sha512": "164d6977e721cbceb44ede7bfd75b03b8d9771e0426aefa5d40c71867e964092fdc6a6808bcbc5559ed73ec2c532ca657d6476af79a49ca3ad879b8366f13d90",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.drawing.common/6.0.0/system.drawing.common.6.0.0.nupkg",
+        "sha512": "d61f0a3e01c3eac15f13fc1ba04a2c7ce4eac956400b2faa361fecabd3836d49d5bd344f3985ee3d94cdc3f6a72b8e07e423cdb2965b4f5ca2222b5de32988e4",
         "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.tools.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tracesource/4.3.0/system.diagnostics.tracesource.4.3.0.nupkg",
-        "sha512": "0655962fdabf1ca334281cee3923aa7211606b932a9ef90ae666fe214edfe1e7089d2ca0865b3047789bde7c30d6bb8198baed748e5ca02041d87d8096d4c5c8",
-        "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.tracesource.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tracing/4.3.0/system.diagnostics.tracing.4.3.0.nupkg",
-        "sha512": "d0a5d30e261cd45b7dfab02b7ffbd76b64e0c9b892ed826ea61481c983c0208b05b69981cd79e91cd4e5811e1cd4c3cea06a1afce05811ece58be5e4c20169ea",
-        "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.tracing.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.drawing.common/4.5.0/system.drawing.common.4.5.0.nupkg",
-        "sha512": "b988b161b074bf3c526dcf41ee3cf0c1403c529a1d6a3de0d99367444596eb3a01c3d0e5b7396d7046b5834238bba011a95274b78137c89016c3987682f26585",
-        "dest": "nuget-sources",
-        "dest-filename": "system.drawing.common.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.drawing.common/4.7.0/system.drawing.common.4.7.0.nupkg",
-        "sha512": "5ca48fb9622fbe9c7c52e93902879af730c356bb276b65570d774f8786c59d75e6ad993ce2af477f9611a8e97967c12373afd0a8cb8a9f1d6e63505da4bed334",
-        "dest": "nuget-sources",
-        "dest-filename": "system.drawing.common.4.7.0.nupkg"
+        "dest-filename": "system.drawing.common.6.0.0.nupkg"
     },
     {
         "type": "file",
@@ -1114,20 +883,6 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.calendars/4.3.0/system.globalization.calendars.4.3.0.nupkg",
-        "sha512": "e97190231402b393774b925efc02a2bfa41d1d117a17fb87da6e399f5234546962767e9cd8f39970efa408e4f453cd1e6751a2a61e366bc97406e1b0b8a4be86",
-        "dest": "nuget-sources",
-        "dest-filename": "system.globalization.calendars.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.extensions/4.3.0/system.globalization.extensions.4.3.0.nupkg",
-        "sha512": "a4d360003f95e0c31edf39c0b91e1c73850a60ac5d0032b17db888a3c7d7134cef9acd97219d14174ad213b7c044f49b364cc5720073ebfcb6e1bf6e4ec24ce5",
-        "dest": "nuget-sources",
-        "dest-filename": "system.globalization.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.io/4.3.0/system.io.4.3.0.nupkg",
         "sha512": "bfca5a21e3e1986b9765b13dc6fbcd6f8b89e4c1383855d1d7ef256bf1bf2f51889769db5365859dd7606fbf6454add4daeb3bab56994ffb98fd1d03fe8bc1e6",
         "dest": "nuget-sources",
@@ -1135,31 +890,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.compression/4.3.0/system.io.compression.4.3.0.nupkg",
-        "sha512": "f540ee51a3bb6941cdfbaace9a9738d7f7986a2f94770db61f45a88ecb7ef36b571d4c07417dc89cdbe9655a262b7cc599b0a4b78effea91819e186121b44807",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.io.pipelines/6.0.0/system.io.pipelines.6.0.0.nupkg",
+        "sha512": "c5983b4510bc8ae4116133ffb9b280fe61d99d47ef52dd78e5bfd03e090901896d5d5fd738dae57006b971840a4d9422bded33ddefa5e927d75d309ef1f70dea",
         "dest": "nuget-sources",
-        "dest-filename": "system.io.compression.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.compression.zipfile/4.3.0/system.io.compression.zipfile.4.3.0.nupkg",
-        "sha512": "1860634672767f818f0192ec2b2750693f0d39390f3b7d400cc6fd4f6e74a5cbed27bf49e5980ec85ff3e161c30f6190f700e339a1040c1699b87eb4aa7b6792",
-        "dest": "nuget-sources",
-        "dest-filename": "system.io.compression.zipfile.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem/4.3.0/system.io.filesystem.4.3.0.nupkg",
-        "sha512": "4fb581d6f85b9529a091a0e974633752aa39e50b2be6c8a9e5eca8c2bc225cea07064ccec7778f77df9987deebf4dccec050b1a97edac0ee9107142e6a8ee7ee",
-        "dest": "nuget-sources",
-        "dest-filename": "system.io.filesystem.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem.primitives/4.3.0/system.io.filesystem.primitives.4.3.0.nupkg",
-        "sha512": "5885953d09582cffd973d23a21a929064d72f2bc9518af3732d671fffcc628a8b686f1d058a001ee6a114023b3e48b3fc0d0e4b22629a1c7f715e03795ee9ee5",
-        "dest": "nuget-sources",
-        "dest-filename": "system.io.filesystem.primitives.4.3.0.nupkg"
+        "dest-filename": "system.io.pipelines.6.0.0.nupkg"
     },
     {
         "type": "file",
@@ -1184,38 +918,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.4/system.memory.4.5.4.nupkg",
-        "sha512": "8ece5491eb0fe332bc190f40cf76b3beee0c5f996325034861be221fdb0ff02fd59e4f7020b3c4a1f29a457f76ff76c4c95d46d38555e4f48c7a3bf172d87966",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.5/system.memory.4.5.5.nupkg",
+        "sha512": "e8c8e536c97b94ac3443c940b30dad43cf6e97dc7a8c3d989371048fe74e168606384f5e0143bdc0d86f7783bf9fdee8417964cb3a8a5d752713e90b125172dc",
         "dest": "nuget-sources",
-        "dest-filename": "system.memory.4.5.4.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.http/4.3.0/system.net.http.4.3.0.nupkg",
-        "sha512": "e8105ce8151aee95852fb29423f73cc1bd7c2286d36474ed7102a4b31248e45f434434a176d3af0442738398c96c5753965ee0444fb9c97525abbd9c88b13e41",
-        "dest": "nuget-sources",
-        "dest-filename": "system.net.http.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.nameresolution/4.3.0/system.net.nameresolution.4.3.0.nupkg",
-        "sha512": "40d39e131fe7a392e58e9f58b516b5db88383de91c05b771f5e509acf46cc874271e90623d327ab039003ab8f2714144694390261278de324e1aee228a828ab4",
-        "dest": "nuget-sources",
-        "dest-filename": "system.net.nameresolution.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.primitives/4.3.0/system.net.primitives.4.3.0.nupkg",
-        "sha512": "9f7fdece330a81f3312ea7c804927852413bee2c929f3066b736993803df47cc0692fbca236c222bf19dc8f59b42f54f2a4c00da9a4d624e458da5874d127ce6",
-        "dest": "nuget-sources",
-        "dest-filename": "system.net.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.sockets/4.3.0/system.net.sockets.4.3.0.nupkg",
-        "sha512": "e32ed9518e9630e99edcf1963c3d0e7047ea8252853c9260eb5403a4206170ae28fd27eb239f39da4d2db766f830b3ebdc9e4da2e697be20241d928082200955",
-        "dest": "nuget-sources",
-        "dest-filename": "system.net.sockets.4.3.0.nupkg"
+        "dest-filename": "system.memory.4.5.5.nupkg"
     },
     {
         "type": "file",
@@ -1258,13 +964,6 @@
         "sha512": "be45051467a36ab965410f112a475fb81510a5595347d1cc0c46b028e0436a339218dd3c073f048c2d338b67dc13b45742290b6c46f55982503f74a8f2698818",
         "dest": "nuget-sources",
         "dest-filename": "system.reflection.emit.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit/4.7.0/system.reflection.emit.4.7.0.nupkg",
-        "sha512": "10c0325b993a31d993c58adeee5f1c6fd7ff66173bf22bf0d295d29bfb30f0e01ec3042aceac5e245bb62d8fbfed63ce02adf74e04cf55811e0cf3d541b897a9",
-        "dest": "nuget-sources",
-        "dest-filename": "system.reflection.emit.4.7.0.nupkg"
     },
     {
         "type": "file",
@@ -1317,13 +1016,6 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime/4.1.0/system.runtime.4.1.0.nupkg",
-        "sha512": "4b05eb68bb485846707c4fe3393f9616d3ffb6c5f62a121d81142ddf7d0241c931fe96d193b7bf02281a9368458e0764466766557cfa9709035dc76d8fdd7706",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.runtime/4.3.0/system.runtime.4.3.0.nupkg",
         "sha512": "92ab2249f08073cfafdc4cfbd7db36d651ad871b8d8ba961006982187de374bf4a30af93f15f73b05af343f7a70cbd484b04d646570587636ae72171eb0714fb",
         "dest": "nuget-sources",
@@ -1331,24 +1023,17 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.5.2/system.runtime.compilerservices.unsafe.4.5.2.nupkg",
-        "sha512": "84c91d5b192cca942515707b25a9907a00ec73110040ee051ddfe5c3fce549953d7598008a3eb9c630ab5deaf5f37c2fa0d033262739cf38e3da873dfdd9685a",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.compilerservices.unsafe.4.5.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.6.0/system.runtime.compilerservices.unsafe.4.6.0.nupkg",
-        "sha512": "fb9cd0d29dd0a1215894b53d1bd7fa5e7f16922ebc204128293e71c4af1e80aaaff31515d8a919736be969eeeba8070860587e11d9a76c45fc1e13e1e67581cd",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.compilerservices.unsafe.4.6.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.7.0/system.runtime.compilerservices.unsafe.4.7.0.nupkg",
         "sha512": "14c154122872d3929f4f691aa2cb8db78f62b8b6e18b278b39a53d128d93b5cc59be330fa9b6b4613c81f9acfe004f1c97f2f815df753a8b97628c17dd543605",
         "dest": "nuget-sources",
         "dest-filename": "system.runtime.compilerservices.unsafe.4.7.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/6.0.0/system.runtime.compilerservices.unsafe.6.0.0.nupkg",
+        "sha512": "d4057301be4ec4936f24b9ce003b5ec4d99681ab6d9b65d5393dd38d04cdec37784aaa12c1a8b50ac3767ed878dae425749490773fec01e734f93cf1045822b3",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.compilerservices.unsafe.6.0.0.nupkg"
     },
     {
         "type": "file",
@@ -1373,45 +1058,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices.runtimeinformation/4.3.0/system.runtime.interopservices.runtimeinformation.4.3.0.nupkg",
-        "sha512": "6f4905329a3cc9e62d274c885f275ee31c5af57a6c9fd1a5080d039cb748e0277bef3dc8ce42863cac78365084e00a032279bf3d2b7254a49f3fb1566a29ad1b",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.interopservices.runtimeinformation.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.loader/4.3.0/system.runtime.loader.4.3.0.nupkg",
         "sha512": "1ba5a6bc023dc8e122e46396b594f7fa92561d719a6ade7da99290ed9ef97c6a5a72594f98b8b334566f6578f70b2b12c8c91006c9b9d1bf714ccff1f4bdf209",
         "dest": "nuget-sources",
         "dest-filename": "system.runtime.loader.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.numerics/4.3.0/system.runtime.numerics.4.3.0.nupkg",
-        "sha512": "3e347faa8e7ec484d481e53b1c219fe1ce346ae8278a214b4508cf0e233c1627bd9c6c6c7c654e8c1f4143271838ddd9593f63a1043577ad87c40e392af7fd34",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.numerics.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.serialization.formatters/4.3.0/system.runtime.serialization.formatters.4.3.0.nupkg",
-        "sha512": "5b852aca669b8826f5c71b8aaeca490b30875bde55650dc60a6ce90d81ef271554bcf636b22c14e00e6b3eef0445a44f52f41168ede3757f06afea1ee58e0908",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.serialization.formatters.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.serialization.primitives/4.3.0/system.runtime.serialization.primitives.4.3.0.nupkg",
-        "sha512": "fcf73baadf5675029e91f2e6e4a71c305eece3671ef69f49440f9c6da160d7b33f0a73923d652f2987f7668093f74ed83de72b185de2ce6ec6b37c6e821217ae",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.serialization.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/4.7.0/system.security.accesscontrol.4.7.0.nupkg",
-        "sha512": "464255881cc1ad9a0df09eaa1ea926c75df4196537a1c5adb180665ec21f8da627d00c778601ee05894ee745664374a38f0369778c98b29cbe236aa70deab5ae",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.accesscontrol.4.7.0.nupkg"
     },
     {
         "type": "file",
@@ -1422,94 +1072,24 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.claims/4.3.0/system.security.claims.4.3.0.nupkg",
-        "sha512": "ab72b90801f6c051a2b31645448eebfca74642b3cfa1d51f80e21a0d0d7ad44d3366dea139347e2852781b7f3bae820df16c3eb188a2c96244df05394ed72c86",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/6.0.0/system.security.accesscontrol.6.0.0.nupkg",
+        "sha512": "64a36a103b954ab4b7e8a76c0e876579bd484c308e444c2d915fb9a0fd05ad63614501ed235c544afc9b431cb8a4cf0f0715b8ed414e85958e6d68579168fb45",
         "dest": "nuget-sources",
-        "dest-filename": "system.security.claims.4.3.0.nupkg"
+        "dest-filename": "system.security.accesscontrol.6.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.algorithms/4.3.0/system.security.cryptography.algorithms.4.3.0.nupkg",
-        "sha512": "7641d70c2ba6f37bf429d5d949bda427f078098c2dcb8924fd79b23bb22c4b956ef14235422d8b1cc5720cbbcc6cfee8943d5ff87ce7abf0d54c5e8bce2aa5e2",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.protecteddata/6.0.0/system.security.cryptography.protecteddata.6.0.0.nupkg",
+        "sha512": "489b5dab0abfadfb8bc2d0437de83a1447918071949440e766db701c81c3518de6a38a3e0f699706b06d591ab5393c7bc0b2eaa81c15bff156339248e6c35730",
         "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.algorithms.4.3.0.nupkg"
+        "dest-filename": "system.security.cryptography.protecteddata.6.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.cng/4.3.0/system.security.cryptography.cng.4.3.0.nupkg",
-        "sha512": "6272273414eaa777e78dca1b5ecbbdf65e9659908082aea924df0975e71f4c1b47f85617edf90ead57078c29513a160ca62f123be9f9f339dfb9c9386844f5ea",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.permissions/6.0.0/system.security.permissions.6.0.0.nupkg",
+        "sha512": "d4f2172cc3b164f104fa2e3a330b62f2a15f50e050a91659db5728f28d4d5d6ca8660eec3a4f922090181a54bc1e9f6634ca49750398360727d1bc59db620278",
         "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.cng.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.csp/4.3.0/system.security.cryptography.csp.4.3.0.nupkg",
-        "sha512": "43317591747a18f52f683187e09adfe0e03573e6dac430bf3ba13f440cdb1c7bb1f9205369d5f3b2a0f3fdf9604d5ba1e6d94a899a25d2c533e453338578f351",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.csp.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.encoding/4.3.0/system.security.cryptography.encoding.4.3.0.nupkg",
-        "sha512": "5c26add23e63542f37506f5fa1f72e8980f03743d529cd8e583d1054b8d8a579fb773fa035a00d9073db84db6be4f47cac340d1ebc6d23dd761dbdbd600075e0",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.encoding.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.openssl/4.3.0/system.security.cryptography.openssl.4.3.0.nupkg",
-        "sha512": "64530a19489730f873f8c68e6b245135ea260c02d68591880261768358d0145795132ba5ee877741822ff05dcd0c61edca27696ef99e8f9302a21cadf3b1329f",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.openssl.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.primitives/4.3.0/system.security.cryptography.primitives.4.3.0.nupkg",
-        "sha512": "5ad8273f998ebb9cca2f7bd03143d3f6d57b5d560657b26d6f4e78d038010fb30c379a23a27c08730f15c9b66f4ba565a06984ec246dfc79acf1a741b0dd4347",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.protecteddata/4.7.0/system.security.cryptography.protecteddata.4.7.0.nupkg",
-        "sha512": "a55ae6196de1e659228213282b1e5b640c8d8337281f914287960bb2057b14aa8e2efa623f789453beae9accbbc8cd6e88022bf9571667f0cd9cc329c2ce3e37",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.protecteddata.4.7.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.x509certificates/4.3.0/system.security.cryptography.x509certificates.4.3.0.nupkg",
-        "sha512": "318d86ab5528e2b444ec3e4b9824c1be82bb93db513eab34b238e486f886c4d74310ed82c2110401fe5cd790e4d97f4a023a0b2d5c2e29952d3fd02e42734d00",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.x509certificates.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.permissions/4.7.0/system.security.permissions.4.7.0.nupkg",
-        "sha512": "9c86c3b424218d618d3028cd4e16e2b93140ee4e082d989a4b234941eb2822e5db9cd42165157e1de7a476482a94b947bc16ad9603888b3a926f63579733b684",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.permissions.4.7.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal/4.3.0/system.security.principal.4.3.0.nupkg",
-        "sha512": "db8a1ed0d189637d9ef83147550ce5da890cf6ec189a7d006ba9de86ab55679e7f025e18bdaed2dc137ddf82a7e6a0131fb4d54d4264831862b1d7c5ee62837e",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.principal.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/4.3.0/system.security.principal.windows.4.3.0.nupkg",
-        "sha512": "66c1d5a9d649b964e1653fa2cd41d8f80515b7cd727fcd7f0890552070da1099ecd1032560f259a108e0d1d6a6da23fa07bc5c922f426a91f33b667f7c004019",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.principal.windows.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/4.7.0/system.security.principal.windows.4.7.0.nupkg",
-        "sha512": "f30a16d34c8792db60b2240363a8b200cab28bc2c7441405cf19abf71dbf5fb0bf3bd1cbec4d9b5eb4cf73ec482e4505d08d80afdef00b2b4b3bb56d6d4cae96",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.principal.windows.4.7.0.nupkg"
+        "dest-filename": "system.security.permissions.6.0.0.nupkg"
     },
     {
         "type": "file",
@@ -1527,24 +1107,17 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/5.0.0/system.text.encoding.codepages.5.0.0.nupkg",
-        "sha512": "4f32c801b3dc8b3d287c17310e8eaecbb7d3d0e311e39e1c428439fea7276860febc38422a61abc93d3cbbcd97bf511835b316553e931e04f6333a80629dc746",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/8.0.0/system.text.encoding.codepages.8.0.0.nupkg",
+        "sha512": "77dadf6b1a73eeefb50507a6d76f5e3a20e0ae7d3f550c349265ae4e0d55f0ae4f0ef1b41be08dd810798a8e01dbba74e2caac746b5158b8e23d722523d473ed",
         "dest": "nuget-sources",
-        "dest-filename": "system.text.encoding.codepages.5.0.0.nupkg"
+        "dest-filename": "system.text.encoding.codepages.8.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.extensions/4.3.0/system.text.encoding.extensions.4.3.0.nupkg",
-        "sha512": "e648c5dc781e35cf00c5cc8e7e42e815b963cf8fb788e8a817f9b53e318b2b42e2f7a556e9c3c64bf2f6a2fd4615f26ab4f0d4eb713a0151e71e0af3fe9c3eed",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encodings.web/6.0.0/system.text.encodings.web.6.0.0.nupkg",
+        "sha512": "0f26afeeaa709ea1f05ef87058408dd9df640c869d7398b2c9c270268ddf21a9208cd7d2bfa1f7fbd8a5ceab735dd22d470a3689627c9c4fadc0ea5fe76237fa",
         "dest": "nuget-sources",
-        "dest-filename": "system.text.encoding.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.json/4.7.0/system.text.json.4.7.0.nupkg",
-        "sha512": "d6ad50bdc50a094b0e0d08cba8d708e77e974b11102b64e618bc8e324ef7288015f91b44ceddd845d974b138277c4a45aa27c32a4aeb0a918fa65929eb088e7c",
-        "dest": "nuget-sources",
-        "dest-filename": "system.text.json.4.7.0.nupkg"
+        "dest-filename": "system.text.encodings.web.6.0.0.nupkg"
     },
     {
         "type": "file",
@@ -1555,10 +1128,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.regularexpressions/4.3.0/system.text.regularexpressions.4.3.0.nupkg",
-        "sha512": "80353c148df30d9a2c03ee10a624d91b64d7ccc3218cb966344cfa70657f0b59c867fed2ab94057f64ab281ad9318353f25c23375c00e1376b6589ae0a70aad3",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.text.json/6.0.5/system.text.json.6.0.5.nupkg",
+        "sha512": "365a854b3a6187af14888fca10573f84c73c9066fec84a25cae233949dcf51ada2efe716ea3d315f8f7cb438ff153ae03ef8ee69e8f24ec3f50971133014e3c0",
         "dest": "nuget-sources",
-        "dest-filename": "system.text.regularexpressions.4.3.0.nupkg"
+        "dest-filename": "system.text.json.6.0.5.nupkg"
     },
     {
         "type": "file",
@@ -1576,13 +1149,6 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.3.0/system.threading.tasks.extensions.4.3.0.nupkg",
-        "sha512": "2c33900ff7f544d6db31ad11b6baee1c9ecb40d5a54f51e5dd5bbbb37f4c50ee35ed481615cbf7c1da61a31ae3333c4454bfbeee4ae32241789e72ce3f910db6",
-        "dest": "nuget-sources",
-        "dest-filename": "system.threading.tasks.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.5.3/system.threading.tasks.extensions.4.5.3.nupkg",
         "sha512": "10bb263e21c5aefba554ba6e9adcfcc31f9f3692f675665b58cf76b5a5bcc2133d56eedba94f422b30be9ad251edcfeba7ebc24a15ff4cb7838072e9bbb18470",
         "dest": "nuget-sources",
@@ -1590,59 +1156,31 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.threadpool/4.3.0/system.threading.threadpool.4.3.0.nupkg",
-        "sha512": "450a40f94a48e9396979e764e494ad624d8333f3378b91ea69b23fc836df8f5c43bbd6c8cfd91da2ab95a476e1ff042338968e09b720447f2241c014bfc75159",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.5.4/system.threading.tasks.extensions.4.5.4.nupkg",
+        "sha512": "68052086e77d3c7198737a3da163d67740b7c44f93250c39659b3bf21b6547a9abf64cbf40481f5c78f24361af3aaf47d52d188b371554a0928a7f7665c1fc14",
         "dest": "nuget-sources",
-        "dest-filename": "system.threading.threadpool.4.3.0.nupkg"
+        "dest-filename": "system.threading.tasks.extensions.4.5.4.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.timer/4.3.0/system.threading.timer.4.3.0.nupkg",
-        "sha512": "d5ce8e258b7be7be268f944e21621195948106f57e6c46e69b2887c46f567760368b14e84046b4be4466ecd08ecd4cb04016a2ff7948cb4640960befc7aa1739",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.windows.extensions/6.0.0/system.windows.extensions.6.0.0.nupkg",
+        "sha512": "f51eec8166f97b5fcea24816ec737c24d5c5a5cb145ef2d33277c9a16044f40bc3fb97b4cfe7f9a23af704ede91586c6abd2acf00b277538bb304d77a1ca54f0",
         "dest": "nuget-sources",
-        "dest-filename": "system.threading.timer.4.3.0.nupkg"
+        "dest-filename": "system.windows.extensions.6.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.valuetuple/4.5.0/system.valuetuple.4.5.0.nupkg",
-        "sha512": "fa00ebb5045d12c51274f64411c551981beceb1266a8606a4731063109b95ea1f15939197bf3d2ba899db61e593dc39bfce876908bba34286823525093ae3d8e",
+        "url": "https://api.nuget.org/v3-flatcontainer/tmds.dbus/0.16.0/tmds.dbus.0.16.0.nupkg",
+        "sha512": "b69917eb43d6518efa591702f927e26366ea59cd3d6a7fb397d485970be736b26576f0c16e047c3e9da3d423753a87c91536633d2cc9c60e565e76a2641e3723",
         "dest": "nuget-sources",
-        "dest-filename": "system.valuetuple.4.5.0.nupkg"
+        "dest-filename": "tmds.dbus.0.16.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.windows.extensions/4.7.0/system.windows.extensions.4.7.0.nupkg",
-        "sha512": "f7bc7cafc5f542a11457a27fdb96ab8a8c8d06851df6d8bc3ac40c2038abc71907feb64ad9ec27ca940d6e51b316f04d2dc3d24cf1b2b5173cde9e20b6aa0709",
+        "url": "https://api.nuget.org/v3-flatcontainer/tmds.dbus.protocol/0.16.0/tmds.dbus.protocol.0.16.0.nupkg",
+        "sha512": "1e6e1bf8ea7c652e5502e96323984157e060ac728843f2104ff8dcab755483ff93ef4df7cc4e7dd4b56047ba42bf349c2681e2fb8d6518328eab002e63d371b2",
         "dest": "nuget-sources",
-        "dest-filename": "system.windows.extensions.4.7.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.readerwriter/4.3.0/system.xml.readerwriter.4.3.0.nupkg",
-        "sha512": "991101497fbd39e43fc306ca280a465318868afa8db1f34bb87c266fe61f0c81a0ec34a797b236ee823bd60d1149b7592def96fe044abb511858efffe890c2e6",
-        "dest": "nuget-sources",
-        "dest-filename": "system.xml.readerwriter.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.xdocument/4.3.0/system.xml.xdocument.4.3.0.nupkg",
-        "sha512": "c2d9236a696daf23a29b530b9aa510fb813041685a1bb9a95845a51e61d870a0615e988b150f5be0d0896ef94b123e97f96c8a43ee815cf5b9897593986b1113",
-        "dest": "nuget-sources",
-        "dest-filename": "system.xml.xdocument.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.xmldocument/4.3.0/system.xml.xmldocument.4.3.0.nupkg",
-        "sha512": "22251b3f16de9aa06e091b24baea1b8c95752f0d22266faf34e1fb76b347b23f7910cdaf567058e23d06b7079961090ca70805070a2491add5da4d0271afd133",
-        "dest": "nuget-sources",
-        "dest-filename": "system.xml.xmldocument.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/tmds.dbus/0.9.1/tmds.dbus.0.9.1.nupkg",
-        "sha512": "ce70e7c1f24026443010a8999f3b60c72bb7409bccebc915650eff06cb072556948c7c8de9f8fe558a7860213982eddb99a4663b526ea1e2b33e94f80da96110",
-        "dest": "nuget-sources",
-        "dest-filename": "tmds.dbus.0.9.1.nupkg"
+        "dest-filename": "tmds.dbus.protocol.0.16.0.nupkg"
     },
     {
         "type": "file",

--- a/sources-x64.json
+++ b/sources-x64.json
@@ -1,255 +1,304 @@
 [
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia/0.10.18/avalonia.0.10.18.nupkg",
-        "sha512": "bfa398495373162d13add9a15c4b65016a08b5405206d45225952ac202ad66fa7e5d157ce3bbf19d78b00389a33e32dee697884144b0678af7f61508826ceb5c",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia/11.1.0-beta1/avalonia.11.1.0-beta1.nupkg",
+        "sha512": "d375b952be419fef340c9f06c5e31ab43fb878d81a3901b640f9f7524fd6f656b3185fe21a0275f85d84ec7b8ca4f0b7d56be29be53434944bb9b2bc3775b887",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.0.10.18.nupkg"
+        "dest-filename": "avalonia.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.angle.windows.natives/2.1.0.2020091801/avalonia.angle.windows.natives.2.1.0.2020091801.nupkg",
-        "sha512": "185412856ea8f3001b19ff03261fa84d3b7b529a2a0eb0a0eada93eac5761e11056f2080373ac5a11449250aadcf61631875e4ca8d5ac5f0e7ef39bd09e93430",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.angle.windows.natives/2.1.22045.20230930/avalonia.angle.windows.natives.2.1.22045.20230930.nupkg",
+        "sha512": "82bb927cff47738cd13ee87f93664eed203fe0586c807c0fb2215e743b01d787c1ab8285512c82a3f891dbd303a20eb1feb24fdfe09a9edd91d9de65ce96f4d7",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.angle.windows.natives.2.1.0.2020091801.nupkg"
+        "dest-filename": "avalonia.angle.windows.natives.2.1.22045.20230930.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.controls.datagrid/0.10.18/avalonia.controls.datagrid.0.10.18.nupkg",
-        "sha512": "44f28349f55156448fea48ea5999d13cc7ab23ed4105ddeccf8b4ee8bb9f05dafe6be3a9375db843758eab17cf3a0efb282ab76896cd6befbfa887c7bc9231ee",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.buildservices/0.0.29/avalonia.buildservices.0.0.29.nupkg",
+        "sha512": "9485e64c84b087beaf0803c049e9c057216b889bb8d452f0339149dbde65b2c9f1cca2f2b119c3d1eb8c6eb135f582edc72516095bb6be9a2d3b530d3aa3d639",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.controls.datagrid.0.10.18.nupkg"
+        "dest-filename": "avalonia.buildservices.0.0.29.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.desktop/0.10.18/avalonia.desktop.0.10.18.nupkg",
-        "sha512": "c33d01e4e766a1bdcf642100bff4cf1c5a868736375a2dd5305c131e265e1cfe69a0d1b2ea4f83104434a066cee33c391bd5968b707ad0699992c0b1662ff118",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.controls.colorpicker/11.1.0-beta1/avalonia.controls.colorpicker.11.1.0-beta1.nupkg",
+        "sha512": "ce1eb2c6d88a33652b61e2215bc38e53d32371e9c99fc101c5d1e53816755f712de7c5f27047180a64f17139635097328fb3717a7af83c6b033a9a79b8bb0729",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.desktop.0.10.18.nupkg"
+        "dest-filename": "avalonia.controls.colorpicker.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.diagnostics/0.10.18/avalonia.diagnostics.0.10.18.nupkg",
-        "sha512": "14ba2ec4aa8ca1756d8a766b48af226fc978502656dff50789bceb064112fb6c4ca7db492f3ebf66fb40b49a9e96d1b8ccafca12587691e2f1b2d57cc5a8d756",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.controls.datagrid/11.1.0-beta1/avalonia.controls.datagrid.11.1.0-beta1.nupkg",
+        "sha512": "d36fcb92469db88f97732b146722a05e1adbaae3993f75a9e0fbf282c9af5ab4d8228e17850206cbd77c7e0b48fdd4bced51be80b432a5a66748323296ea8796",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.diagnostics.0.10.18.nupkg"
+        "dest-filename": "avalonia.controls.datagrid.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.freedesktop/0.10.18/avalonia.freedesktop.0.10.18.nupkg",
-        "sha512": "ce5edac45a9069ec62cbb843ad4ae310ad407785b6ad8afe23bf98c6b28ab9b6d067f313f0432db605e0c9e444ceaad8f77f7dda1839bd3e97da635cbd9e6afa",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.desktop/11.1.0-beta1/avalonia.desktop.11.1.0-beta1.nupkg",
+        "sha512": "4b3f977c76947d996a9245de4f82d150a587150047510b806cb7889b30eb8b83e36ff8cdf831e82ce78851e2dab55ef6059c590f17a57531c7650430147c5218",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.freedesktop.0.10.18.nupkg"
+        "dest-filename": "avalonia.desktop.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.markup.xaml.loader/0.10.18/avalonia.markup.xaml.loader.0.10.18.nupkg",
-        "sha512": "10f39212273470112788c70a924e0ceae03fb203688af4001b0106d34cd9c9b012e46e9e7b28239b43c65d9c8dac9c20c6f16c6a917ff9ef04a64fed0aaf350d",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.diagnostics/11.1.0-beta1/avalonia.diagnostics.11.1.0-beta1.nupkg",
+        "sha512": "b64cf69a7d0d2d18cf9e2e9d2dd37620024a5c42cbb6a58abbc0df02fe6c905a2c8389fc8b1cf678544eea0dbf84dd8befc187ead2b709dadc35dfa6334d516f",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.markup.xaml.loader.0.10.18.nupkg"
+        "dest-filename": "avalonia.diagnostics.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.native/0.10.18/avalonia.native.0.10.18.nupkg",
-        "sha512": "9bba27cbd6b0082157ed3f5c3d8d02a11f98e4148aef11062daee11c4f763919e89e1bbe124581bcfd611151faecc037835f38099ee026467e5c07ce094ba522",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.fonts.inter/11.1.0-beta1/avalonia.fonts.inter.11.1.0-beta1.nupkg",
+        "sha512": "26c97f558cd54b653e1479546e3ebfdc3020227b6aa2384443dd44e9f1e63b49fd987e20ae9ce53cf3e72535d9feac871ccc61ca25d309cfa9955f54719eaa6e",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.native.0.10.18.nupkg"
+        "dest-filename": "avalonia.fonts.inter.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.remote.protocol/0.10.18/avalonia.remote.protocol.0.10.18.nupkg",
-        "sha512": "3d4ccc0821212b7e13dce1a7bdd2fd616ad18c111989389080cd95922198ed3aa57617740aff08c77c15f65c5790373be752614fe2956efbbeb133a2f9b2d358",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.freedesktop/11.1.0-beta1/avalonia.freedesktop.11.1.0-beta1.nupkg",
+        "sha512": "f0cfb10e3e50d891cb4bc47e416d63d72418d069bb7bb04e69f8e7681fec4d4b7f6439d2a484204766715cd36cd889512f213fc3739498e7a560267d3d29b917",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.remote.protocol.0.10.18.nupkg"
+        "dest-filename": "avalonia.freedesktop.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.skia/0.10.16/avalonia.skia.0.10.16.nupkg",
-        "sha512": "e87d9143931370884c4e4b54b672938f07b24ae11da67c67441a45c55182d44858828ac66dab67a9313235b69af939cd5b77d09ab428911abab7c28f6e3ac06d",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.markup.xaml.loader/11.1.0-beta1/avalonia.markup.xaml.loader.11.1.0-beta1.nupkg",
+        "sha512": "fb2cd8a393e26b92e60c557defc333a990bfe25a3e9d67f1d143c13629b2e2c298cd946a205f26ab55e49545067366f8b238dbd3afef2a490e13c49fd96f3a0c",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.skia.0.10.16.nupkg"
+        "dest-filename": "avalonia.markup.xaml.loader.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.skia/0.10.18/avalonia.skia.0.10.18.nupkg",
-        "sha512": "eb60286c911526e60366e21aa3f99a439a916144f24ec99e050007f125cc8e45bafd9963bdd6cc4c897f35369aefacfb42976fff5ba795c80b0405027523fa7c",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.native/11.1.0-beta1/avalonia.native.11.1.0-beta1.nupkg",
+        "sha512": "05fbab0b3cf5aca8d020e26b65224d61dbb6ac2e8d5084adbf89f41ada641f4559a000dc7e54f565a5067e91faa1cb076c939b8b44d12567e4e3fe10053c7e7f",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.skia.0.10.18.nupkg"
+        "dest-filename": "avalonia.native.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.svg.skia/0.10.16/avalonia.svg.skia.0.10.16.nupkg",
-        "sha512": "dfb366224c847c2fcd4400b6b4e4f9ee5f24106d173254a76b9bc6f4b88b31c4846fd3686d079220741d89460c7d65ceaa9f6939c82f9624608668541bdc3aa0",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.remote.protocol/11.1.0-beta1/avalonia.remote.protocol.11.1.0-beta1.nupkg",
+        "sha512": "96ae5522db75b4298848be51196ee9a8f5b5021c91ec8a9f0d24c4fee8c074b7fdec03765df1152fbf7c090dc4630e72cd27a8c6bf050dfdca429b520bcef1e9",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.svg.skia.0.10.16.nupkg"
+        "dest-filename": "avalonia.remote.protocol.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.win32/0.10.18/avalonia.win32.0.10.18.nupkg",
-        "sha512": "4d5218edbb80420c9b90052bc1a6ecff2d8bb05598fb9bf93c7496ac196de4d3b83d3b52c286a1ccfa3c68117df32fb9789c492f8abb90c4bb457e108908a58d",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.skia/11.0.0/avalonia.skia.11.0.0.nupkg",
+        "sha512": "6fe1db10ed9422decd24fb60801d9b63651f0bd3f046a9e9d566d0816e7f3fb70eb4cf23db173537a5d5d8e1b75c2999793e5503648fa200a31806c6591b2723",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.win32.0.10.18.nupkg"
+        "dest-filename": "avalonia.skia.11.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.x11/0.10.18/avalonia.x11.0.10.18.nupkg",
-        "sha512": "3dd443fb5436c7362eac851527a08710a5d02d9fcca93b8d1667dcb2d9e477ef814e674285eef415cc52ac98f22b6cfe1f364462fc064052b0de666778acd4da",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.skia/11.1.0-beta1/avalonia.skia.11.1.0-beta1.nupkg",
+        "sha512": "a4a150a1192abad079ef0e763b718b97d63cbe71315ce7a46f96bc108555c23f1b8a6dbbfb54e6da5b97acee997cef8af23b4ca5485e887a284bc9622731d876",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.x11.0.10.18.nupkg"
+        "dest-filename": "avalonia.skia.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.behaviors/0.10.17/avalonia.xaml.behaviors.0.10.17.nupkg",
-        "sha512": "1061eccdd870b56e3b7e55ace8eb1499702c3f2656315cd3716fcf51868aa5140ed2e90bfc036721ddf52928e878b2a9c97f83df75f59aab39edf6a2b9ee21c2",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.svg.skia/11.0.0.13/avalonia.svg.skia.11.0.0.13.nupkg",
+        "sha512": "e6888dc587451a2fdb7bf708d7924fac5c121479cc9754958d96f6e4036c752b56a1e231b35b66519b5a6942993943f63611638e46986f33a3c9a9f436f913e9",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.xaml.behaviors.0.10.17.nupkg"
+        "dest-filename": "avalonia.svg.skia.11.0.0.13.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactions/0.10.17/avalonia.xaml.interactions.0.10.17.nupkg",
-        "sha512": "1b88d9644b330f75bb2bdb9b2ec815918b21339eb263457ca99ffca652ae90d33480a2cff0d8adf04e8cb936734cd47d670ce642f8dde22d5e432fae16185ec9",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.themes.fluent/11.1.0-beta1/avalonia.themes.fluent.11.1.0-beta1.nupkg",
+        "sha512": "774bb2f1928c859f3ea6a6d4ad17bd69ad3f56d3901c7cca456c6f163137b366be19499f08c118bee1fb01155e3344bb81048248faea34eb628f3be0b57d5b17",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.xaml.interactions.0.10.17.nupkg"
+        "dest-filename": "avalonia.themes.fluent.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactivity/0.10.17/avalonia.xaml.interactivity.0.10.17.nupkg",
-        "sha512": "62c18cc0a3c081dfee78e007fed17f2fbaa39a8599c0d130c4368ac319219ed4181b6a77c15f0d864d1fec6ed6853e9356683f9a440dd8f2c4bae2d7f00b7aef",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.themes.simple/11.1.0-beta1/avalonia.themes.simple.11.1.0-beta1.nupkg",
+        "sha512": "e2a06fc69aadbdd7840cd197e264a6379c9982ec215dad547e48595864c5dbf2db642bf728070ab3324a7d91c42635db0c2817feec6fcfc97f8303d8d4f54ccd",
         "dest": "nuget-sources",
-        "dest-filename": "avalonia.xaml.interactivity.0.10.17.nupkg"
+        "dest-filename": "avalonia.themes.simple.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/castle.core/4.4.0/castle.core.4.4.0.nupkg",
-        "sha512": "7626c347f82038bc29b0b2ae399937047aead260ed85ff8c107d36adbe901d729be59cd89a5f98ef45da2d1883c8374b6f286c81c044a5a2b69ab4b5dde9ce98",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.win32/11.1.0-beta1/avalonia.win32.11.1.0-beta1.nupkg",
+        "sha512": "1fc85025e0d00f1ae79a7a81ab5ca33d2e1d823ea91c14931552ca7cc3bd33deec0f033b0306dc994da8938a79d9eff6eaac3b8c884ab23a8403441ac9e8aeb4",
         "dest": "nuget-sources",
-        "dest-filename": "castle.core.4.4.0.nupkg"
+        "dest-filename": "avalonia.win32.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/config.net/4.15.0/config.net.4.15.0.nupkg",
-        "sha512": "4d9e4910f15dac857b811ece2b90e59a5c55a246a81ca093e635744f0b8b3737cb99235d60a2fb7f0a054c320cbb1c03d03d4c5c988c10553b594c6a813a0a9e",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.x11/11.1.0-beta1/avalonia.x11.11.1.0-beta1.nupkg",
+        "sha512": "f1f08b32ba67e60bdce50629d5ab215f2e196dc2ade8f400e66c039f8cdf12c04b6893f8ac0a3f23571045e70b30b969fe6e1f26d70edd8bfcb183b1e44de43f",
         "dest": "nuget-sources",
-        "dest-filename": "config.net.4.15.0.nupkg"
+        "dest-filename": "avalonia.x11.11.1.0-beta1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/config.net.json/4.15.0/config.net.json.4.15.0.nupkg",
-        "sha512": "c0c4e218de8b4359ee8825dd6625ecee568cc2ca164bbf1ed9b7af1acee02f42bad35a5c8093e2d6d76de1a6d235ec87b338e50179b4f20e35d9db0d2ea1c12d",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.behaviors/11.0.6/avalonia.xaml.behaviors.11.0.6.nupkg",
+        "sha512": "452b63f4f45411e00fd57f6a6bf42ff7839f9dbef31683e5b4b2b5eb2c90fe2a579c9c5ccc7380eed05823268bfb35ce99bf06633c3de7e919ddd8c7ec8e4ee7",
         "dest": "nuget-sources",
-        "dest-filename": "config.net.json.4.15.0.nupkg"
+        "dest-filename": "avalonia.xaml.behaviors.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/cs-script.core/1.4.2-preview/cs-script.core.1.4.2-preview.nupkg",
-        "sha512": "4b9fb804ec36ccd392760acfd51a958632f58f72c3c5b00177aa16a187ed4ee40cdb0083e44de315aff0bf42541616de7523dc15ffab94b258f21211e3bc5432",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactions/11.0.6/avalonia.xaml.interactions.11.0.6.nupkg",
+        "sha512": "6c226ecc2717223e8e7b461b9f542abb397b199d869bc7ab9ba0772ec83004f2fe9767aafc2596f07d78b6dd35ee2e9b47f3e4f9fd4c7c164feccda0a59cb87d",
         "dest": "nuget-sources",
-        "dest-filename": "cs-script.core.1.4.2-preview.nupkg"
+        "dest-filename": "avalonia.xaml.interactions.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/excss/4.1.4/excss.4.1.4.nupkg",
-        "sha512": "7de5ccf229c00c2d20a7c89bab3a9e2ff190c8dc67845098e4a49ce284a81b77a7dd6fe5736a69bfa638b72ae30c75e3b39a4c08ed8a8083f21bbdf5db059f33",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactions.custom/11.0.6/avalonia.xaml.interactions.custom.11.0.6.nupkg",
+        "sha512": "03fe107015f04015f833222ba252d1aa4abe57e1f5f9114466c45220a2eabc53a1a537303ff3a6a17455a2a1a7f3497add25647f392d84b80d4121a701181232",
         "dest": "nuget-sources",
-        "dest-filename": "excss.4.1.4.nupkg"
+        "dest-filename": "avalonia.xaml.interactions.custom.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/fizzler/1.2.1/fizzler.1.2.1.nupkg",
-        "sha512": "4a0fe8626c283acce7c7fe0406222a0195ad203515b2af297b0f9268646e54b860010eba96562ba2cf1e44deb1e903ddc81c26374cd6ca522318e36e94655520",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactions.draganddrop/11.0.6/avalonia.xaml.interactions.draganddrop.11.0.6.nupkg",
+        "sha512": "74cb5edfc57376480e3ee7e1914eb7aaa807d19eeef02c01b3c84abf605eea166bc514d9f481328cb5176fb3d6a6d7482dba4878dfbdae75f635bddfdf379fde",
         "dest": "nuget-sources",
-        "dest-filename": "fizzler.1.2.1.nupkg"
+        "dest-filename": "avalonia.xaml.interactions.draganddrop.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/2.8.2-preview.178/harfbuzzsharp.2.8.2-preview.178.nupkg",
-        "sha512": "a0c81fe7d6c81a2adc0b51a49f21e860fe4ba0dbcd291a0c05316667dc55561539b55f88fe22aef144d7dcbc369aa4492f525957d7420d00d5e194556ce13b8d",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactions.draggable/11.0.6/avalonia.xaml.interactions.draggable.11.0.6.nupkg",
+        "sha512": "7f00693ae9fea5ec05d9defa8947de5fc25dd3a58f19ef997807615558898713e3e74ff5618bc53d736efbad9c53151b9d8275609fe17f55f2a0f5bc4ae472b0",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.2.8.2-preview.178.nupkg"
+        "dest-filename": "avalonia.xaml.interactions.draggable.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/2.8.2.1-preview.1/harfbuzzsharp.2.8.2.1-preview.1.nupkg",
-        "sha512": "a7ade98e423293b73bfd39aca7e18ee7f928350ebeb7fbc9d0ed0820af174d075c7c367cf03677285ff6db36bd9a63257fd23b0ec416fa4992ca6f50c752b44b",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactions.events/11.0.6/avalonia.xaml.interactions.events.11.0.6.nupkg",
+        "sha512": "2e6fa3c1a23e2815a5d972625c6545e9737f1bb4e668b9bb554fafd9422ddf0a9fad53ccbc7c88620adf2e37e84d489f17ef286a7f395516cddaebbe722e4017",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.2.8.2.1-preview.1.nupkg"
+        "dest-filename": "avalonia.xaml.interactions.events.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/2.8.2.1-preview.108/harfbuzzsharp.2.8.2.1-preview.108.nupkg",
-        "sha512": "3de9e6ea186df99fd9a6d1d48908cc3d36ac9b7d1d16dfe5adef99b29d43eab6cd27b5ac85479d054b6cdc05cc92acdd981dfa1d46bfafedda3d83b28394cbe5",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactions.reactive/11.0.6/avalonia.xaml.interactions.reactive.11.0.6.nupkg",
+        "sha512": "77ce9677f2b71020fb7386a277559c07906d6e1b7ef4cba987a6e47b7c61c62c2dede50d8140d7102f1754e47facc32523ad17da31dcd3bf2d2e1ecf4898ba31",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.2.8.2.1-preview.108.nupkg"
+        "dest-filename": "avalonia.xaml.interactions.reactive.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/2.8.2-preview.178/harfbuzzsharp.nativeassets.linux.2.8.2-preview.178.nupkg",
-        "sha512": "d549c4494f7954f02a8667b2663be4b70bec42bc6ba6ba867ca0fab0e39ba2a83c2c7db03f7ab3c65ed7976e997a0f010519d6b25335c41d02defad809b3b8f7",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactions.responsive/11.0.6/avalonia.xaml.interactions.responsive.11.0.6.nupkg",
+        "sha512": "a43d7c00efc472ccfb1203d169c832ab828fcfa6d90d547ecaca1704481ac04b03e1a30a088466f7c31bc689ed55aaf58fc692c4ec854140002474549875de59",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.linux.2.8.2-preview.178.nupkg"
+        "dest-filename": "avalonia.xaml.interactions.responsive.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/2.8.2.1-preview.108/harfbuzzsharp.nativeassets.linux.2.8.2.1-preview.108.nupkg",
-        "sha512": "8935254107ec9580e920d810f4b5e9c2e2b6088bab7ccbd41a17b6da77a0b47b0be08f9d75d2c320b9b98c2753c00cb7955504786988d3254d3fdea18c46a3d8",
+        "url": "https://api.nuget.org/v3-flatcontainer/avalonia.xaml.interactivity/11.0.6/avalonia.xaml.interactivity.11.0.6.nupkg",
+        "sha512": "235cb134fe555e44a6802b15da1cc3c689fe613ab5d7a6901c6499603395ffb9edebb76ab35048d465f8c95d64bd70e500216394d91cbfa393f333bc85af5b6f",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.linux.2.8.2.1-preview.108.nupkg"
+        "dest-filename": "avalonia.xaml.interactivity.11.0.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/2.8.2-preview.178/harfbuzzsharp.nativeassets.macos.2.8.2-preview.178.nupkg",
-        "sha512": "587acc0a42eb40e0cffbb557bd048031b5cf4190c41831ce783a48159bbc32490274d0c19729fb6fd4c84a8c3094690fa34a24d38bbc48fd5015e70de0e9e4ec",
+        "url": "https://api.nuget.org/v3-flatcontainer/castle.core/5.0.0/castle.core.5.0.0.nupkg",
+        "sha512": "210328587ff705f78fa46a9e1bdc07c5a8110335122d533f604bde9382b6317677a3168cb4238a45483fc38bd3d2661738f6afaecc42d170b7ba778912cfa74e",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.macos.2.8.2-preview.178.nupkg"
+        "dest-filename": "castle.core.5.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/2.8.2.1-preview.1/harfbuzzsharp.nativeassets.macos.2.8.2.1-preview.1.nupkg",
-        "sha512": "567421cb185a7194b003f4bd8005146b2d0d4e298abb2e6118db109a0384e34f7e06023ed5dcf10dd393841aef51b53beb11997e33a0f06bbbfde1ed321c9ecd",
+        "url": "https://api.nuget.org/v3-flatcontainer/commandlineparser/2.9.2-ci-210/commandlineparser.2.9.2-ci-210.nupkg",
+        "sha512": "2aa0c5d45d93a80eedc507f0e1cde2c7fb996707ea16cbb695313ef1636e74b1a46aa6d55226690c5f1b1a2b33fa4c9d24f22ad0552daefbb28c102a5675ba17",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.macos.2.8.2.1-preview.1.nupkg"
+        "dest-filename": "commandlineparser.2.9.2-ci-210.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/2.8.2.1-preview.108/harfbuzzsharp.nativeassets.macos.2.8.2.1-preview.108.nupkg",
-        "sha512": "dde20e55f099d3de444d03d1a0da1fe074d8a074b32c43b8ba0e3a2d45fa66fb48b9db2c9a790183111634e3edbf67065a4501f036df9fbbd3fbf870db8c342f",
+        "url": "https://api.nuget.org/v3-flatcontainer/config.net/5.1.5/config.net.5.1.5.nupkg",
+        "sha512": "2c0eb61eee0ada0c92bb5f17e5643d61c880723f06554b08147de03e79bbd6d3e538ccb0006fb0ab28ba95db8e58e76ac92ed3d73c8d2bef7b07db27393022d4",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.macos.2.8.2.1-preview.108.nupkg"
+        "dest-filename": "config.net.5.1.5.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.webassembly/2.8.2-preview.178/harfbuzzsharp.nativeassets.webassembly.2.8.2-preview.178.nupkg",
-        "sha512": "4d1af17dbee025df0870ad9e61b05d5e4e0c173a0cc0f31fbcca22f0697dab1f9fea1579379869ef7a47d47da1e3642bdfa484565667998d05d50b42db93a2ac",
+        "url": "https://api.nuget.org/v3-flatcontainer/cs-script.core/2.0.0/cs-script.core.2.0.0.nupkg",
+        "sha512": "c9328cd6a189bacd21c69afb1657852dc9950e0532e2b6f5688e6eb09f96fd3fd3702f664e2506ac9288e3bcdc4cb57077657f2e49196600c46439183e703c34",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.webassembly.2.8.2-preview.178.nupkg"
+        "dest-filename": "cs-script.core.2.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.webassembly/2.8.2.1-preview.108/harfbuzzsharp.nativeassets.webassembly.2.8.2.1-preview.108.nupkg",
-        "sha512": "da78dd24556af8562b2ee4e53e49e7c17ba31f0a16e7b7a588371bdcf26a52af73fb60887253b6bc2e1e69dee94d38feb1730de0ad718753260120599b0ceee2",
+        "url": "https://api.nuget.org/v3-flatcontainer/excss/4.2.3/excss.4.2.3.nupkg",
+        "sha512": "fcb06d04937a6bd864060e8bdf4a65970c7450cdbdd3279465851310ac8bf12b645cac54ce8b7a8039c7ca9309ba3d9ee4e23827599479c4140f7755e119caa9",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.webassembly.2.8.2.1-preview.108.nupkg"
+        "dest-filename": "excss.4.2.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/2.8.2-preview.178/harfbuzzsharp.nativeassets.win32.2.8.2-preview.178.nupkg",
-        "sha512": "665318ba6d2fa1a4746e180ff3a122f19f7a175171a0bcf24bef0dd4a84f2f7fdfce7196bd7044b20051be2d074fe979e6e5eb1aeb7e76dbc8b8b6f3749307d0",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/2.8.2.3/harfbuzzsharp.2.8.2.3.nupkg",
+        "sha512": "44cdcfa570a075d28338f3b720ddc61c9eb3421ef14dabbcb751bd2103fb192d3fd0dff55ebac192db711c02b4d361bb652f55fa3e52c922110f3d3bacc8a173",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.win32.2.8.2-preview.178.nupkg"
+        "dest-filename": "harfbuzzsharp.2.8.2.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/2.8.2.1-preview.1/harfbuzzsharp.nativeassets.win32.2.8.2.1-preview.1.nupkg",
-        "sha512": "8fb5b9043626dbcb7a51e3f37d80f87a9ea4bb8eb9164297290d5d690d7394fb5fa7e462f1929e739c9f769ac499d348f6cbc10d34b28afee4ae6ca34e356441",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/7.3.0/harfbuzzsharp.7.3.0.nupkg",
+        "sha512": "5d1887b3cdc22334132f8fff8b2ac1f57cb54e9fcd25d21d32f8f86c7c694e86739c067e8b1ae3da10c1b1b3417f27b640b0e7890101ee2d420fba3feba580b5",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.win32.2.8.2.1-preview.1.nupkg"
+        "dest-filename": "harfbuzzsharp.7.3.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/2.8.2.1-preview.108/harfbuzzsharp.nativeassets.win32.2.8.2.1-preview.108.nupkg",
-        "sha512": "4ce79a68b383b466b690fcede1986103c2d88b99a92114e90ba32e07d802fe8436949272b4992bf366a0fbfa452699b9715532ab0ddb7746a3c4cc431a30a737",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/2.8.2.3/harfbuzzsharp.nativeassets.linux.2.8.2.3.nupkg",
+        "sha512": "fde70d49dc1e90c9ac171b643f6e3939071cb2197bc8101ede4c3ce7f1ab7581d945d4c91d103bc63243c017ec2688d791880e348c24908bb7651e983f0f0b13",
         "dest": "nuget-sources",
-        "dest-filename": "harfbuzzsharp.nativeassets.win32.2.8.2.1-preview.108.nupkg"
+        "dest-filename": "harfbuzzsharp.nativeassets.linux.2.8.2.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/7.3.0/harfbuzzsharp.nativeassets.linux.7.3.0.nupkg",
+        "sha512": "48a4bf98b9f59181ef1885a3d4d3ee605b63aeab3b49248a3e49a6bbbdcdae4bcb974073492319789f17eb92edebc1ddf050c5d0724eddc5ea3277d5c2054731",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.linux.7.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/2.8.2.3/harfbuzzsharp.nativeassets.macos.2.8.2.3.nupkg",
+        "sha512": "6f371912b52eba613883bb1403f5d9be271662fb15f33fb27b332fa8a33cd0944ec86a24b8272f80ca82fbbf04287ac745aa245571a7bf49970db83a0d61376e",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.macos.2.8.2.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/7.3.0/harfbuzzsharp.nativeassets.macos.7.3.0.nupkg",
+        "sha512": "803ace4c95a3ae0c69e30003d3f6dc1b409ff0390b94c37d8dbc1a5321dca74b5d7b2a8aefaab0a792cd47d4e3c2d24e733ed313e0597d80a7ef81b67bc413ee",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.macos.7.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.webassembly/2.8.2.3/harfbuzzsharp.nativeassets.webassembly.2.8.2.3.nupkg",
+        "sha512": "9d0521518020b38f05b206c146102c8441b3f1c2ee604b26bb733382449bf45cc24d3a11320ebb3ccc396d86c64a5d1de37f0622a712f2a590c2c2ea2098e262",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.webassembly.2.8.2.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.webassembly/7.3.0/harfbuzzsharp.nativeassets.webassembly.7.3.0.nupkg",
+        "sha512": "eb0925b18271e435f1b90fabbefef4d01bf4d1443628509f66b4f4ecf8603bba91abac29b3b19a09170f491986c89d7a37d43f854d15379d9e74b27cbad6fae8",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.webassembly.7.3.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/2.8.2.3/harfbuzzsharp.nativeassets.win32.2.8.2.3.nupkg",
+        "sha512": "f51176b5bf944d8cee7b17269a43d43bd2297506ced8d16c87d3e8d421d68d71f85e8eb20982e5af902f53e20382709a9a0500140e5a74b758af35193f1bb771",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.win32.2.8.2.3.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/7.3.0/harfbuzzsharp.nativeassets.win32.7.3.0.nupkg",
+        "sha512": "3f477b5cb4d70df1333f69272c885c31dc43118ebf4edc990ae6ea8f29db0a3d4886a74b6d7ad2778d1db6bf7660bf0ae0eb23030c0b9c65710c5baa2389b00c",
+        "dest": "nuget-sources",
+        "dest-filename": "harfbuzzsharp.nativeassets.win32.7.3.0.nupkg"
     },
     {
         "type": "file",
@@ -260,13 +309,6 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/jetbrains.annotations/10.3.0/jetbrains.annotations.10.3.0.nupkg",
-        "sha512": "ad0c0fdda8d66adbb5da6c83b562df9c45b1cb7ec146c892747cbfdcf4409b1e9d620840378cceb2a94889d7e4d3cd4318347b736eca97e801e59d2dcfb78afc",
-        "dest": "nuget-sources",
-        "dest-filename": "jetbrains.annotations.10.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/libsodium/1.0.18/libsodium.1.0.18.nupkg",
         "sha512": "3c561728300bbb52b4cc191be11682edab3ee7e8713d8bf9931ca6ce88d280e1232160f2efcb0138ea2be84805ab4a6d2699edc2cf63a7cd28d81e0f2f5cf98e",
         "dest": "nuget-sources",
@@ -274,24 +316,24 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnet.webapi.client/5.2.7/microsoft.aspnet.webapi.client.5.2.7.nupkg",
-        "sha512": "4bc85f71e527cb90b4fb27f7075aba132ddfcac6c7e1ca3061a72723bb752c85f9de9154a6534bc3166098d2b61a4370fe113af10dc0cbedcd892d1e5724774a",
+        "url": "https://api.nuget.org/v3-flatcontainer/microcom.runtime/0.11.0/microcom.runtime.0.11.0.nupkg",
+        "sha512": "c00731176e34ea7b936ad58a38639843c790b027b714ed5d3ea828b85ea94b14a502ded52ca7f60bb10c0ac0e744bd6e62fdcce0108ebaaf9731c408eece031e",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnet.webapi.client.5.2.7.nupkg"
+        "dest-filename": "microcom.runtime.0.11.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/6.0.25/microsoft.aspnetcore.app.runtime.linux-x64.6.0.25.nupkg",
-        "sha512": "b4633649cdd291f03505712bd518627494a65773f68a958f51658e22f5773a09857c8f0fbc3d3db7cde33e9c17a66e34b2e7f80fbcb2733c45fc669eb096b796",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnet.webapi.client/6.0.0/microsoft.aspnet.webapi.client.6.0.0.nupkg",
+        "sha512": "47d509834cca423ca9a6393ee4b6b7c56149d93dae96ac02b0712cd39bfd642969402a93a8cba924171e0103c915a3ab892e20a54e49943138f0509c1d51bccd",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.6.0.25.nupkg"
+        "dest-filename": "microsoft.aspnet.webapi.client.6.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.analyzers/2.9.6/microsoft.codeanalysis.analyzers.2.9.6.nupkg",
-        "sha512": "30b2d92add884d8bdc62a40605dd314b7ce9c80a23ae64962b6745b35c302a3868d237be4b27a292cacbd1b80cc6ecfb1cb444108c07750eff8f400fe3e13470",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/8.0.3/microsoft.aspnetcore.app.runtime.linux-x64.8.0.3.nupkg",
+        "sha512": "b4a7945b58402ad226e28a6e4a0f36aa770f72c27ad3a97aa2292f531ea581e7de9cc9d5e97550784e945250c0f9fa70d82338ce5e08834403b386d50455205f",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.analyzers.2.9.6.nupkg"
+        "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.8.0.3.nupkg"
     },
     {
         "type": "file",
@@ -302,24 +344,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.common/3.4.0/microsoft.codeanalysis.common.3.4.0.nupkg",
-        "sha512": "652914ddc4c651c6c68265636c3c4bc76b9207b745387e57345db4d9c44b6346a6a267550db9c153cd2f3fc248bd4a69ee55b4da8a0e07285b09324792e466e5",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.common.3.4.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.common/3.6.0/microsoft.codeanalysis.common.3.6.0.nupkg",
         "sha512": "e17e766686185b48ec4357615fb296b70c19956cb57be3712fdad6984c6908b619001b7fe2a85b5d172e9254fa82eef8a06ddfa3f8cfc42079135bf5eee81d3b",
         "dest": "nuget-sources",
         "dest-filename": "microsoft.codeanalysis.common.3.6.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp/3.4.0/microsoft.codeanalysis.csharp.3.4.0.nupkg",
-        "sha512": "271ec0ee5949771958cd05b63bf2a879f97abcfe8275bb36a40ad22e4a700614115517820eaae752f05fe24c338efa06d8ae3f667b04c91c1db8d9be8a9749e1",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.csharp.3.4.0.nupkg"
     },
     {
         "type": "file",
@@ -330,24 +358,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp.scripting/3.4.0/microsoft.codeanalysis.csharp.scripting.3.4.0.nupkg",
-        "sha512": "c3ea6676face82f86a2ca46224f668e5516a233e5229cf4ed75f7172612ed675ae87e1ee3eb10fd7568dd641721a302b140ee6867c2bc9a102339400ba80340f",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.csharp.scripting.3.4.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.csharp.scripting/3.6.0/microsoft.codeanalysis.csharp.scripting.3.6.0.nupkg",
         "sha512": "41a55829957cfd04a02dc2c64c3299aa4dbf3c8236cb079993e5e28884d08cf004f1e912e21f7adb73e76ca1f7be26638d339795f0a8ad0ceae7d20e9894ddd8",
         "dest": "nuget-sources",
         "dest-filename": "microsoft.codeanalysis.csharp.scripting.3.6.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.codeanalysis.scripting.common/3.4.0/microsoft.codeanalysis.scripting.common.3.4.0.nupkg",
-        "sha512": "ad40179f4516a236ca01f65c4762d0420fff5738177dea5506eb5d66e0f431e52cf0e36a0777c4db8f5748e69ea506e54fb0dc0a5f0e28af2e7e6968020c73f5",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.codeanalysis.scripting.common.3.4.0.nupkg"
     },
     {
         "type": "file",
@@ -372,10 +386,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/6.0.25/microsoft.netcore.app.runtime.linux-x64.6.0.25.nupkg",
-        "sha512": "28de604641e5c0fe694afb9fb394139074c240e331c7bf2513843ef39309f83fc6fe49eab657082548f29557cda602f2d310fb83a190bade076858227a111e62",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/8.0.3/microsoft.netcore.app.runtime.linux-x64.8.0.3.nupkg",
+        "sha512": "daa23233228fea5a97db85f7e39f5360a9ae60df3ae9960ff7dfd4c6ab5e60ec99725197579aeb76bc57b1fd4500533b12070647bba17d5b5f7de048364b8d94",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.6.0.25.nupkg"
+        "dest-filename": "microsoft.netcore.app.runtime.linux-x64.8.0.3.nupkg"
     },
     {
         "type": "file",
@@ -393,31 +407,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/2.0.0/microsoft.netcore.platforms.2.0.0.nupkg",
-        "sha512": "0827f83639833a88ac7bb1408a3d953ee1c880a2acbbaf7abe44f084e90f5507cbb13981d962c57d0e3278ee5476d93c143eb7e9404cc7a63d7a8bf324a4fbe8",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.platforms.2.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/3.1.0/microsoft.netcore.platforms.3.1.0.nupkg",
-        "sha512": "636a1e3768f782ced193b18ec61616c122b5b756395bbec3ede805b172ce62db2d631407deebba73bf136234479be4824f0268a57f52ff4f8d7d37d4370cd966",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.platforms.3.1.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/5.0.0/microsoft.netcore.platforms.5.0.0.nupkg",
         "sha512": "8493fe11648c7ecc20b6530490d30fd63744961345c0501a7a10b11046661da09b783ddceb8b3208ae52a72a8a94cafdce8dc1bd6073c32081e30d0e7407f174",
         "dest": "nuget-sources",
         "dest-filename": "microsoft.netcore.platforms.5.0.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.targets/1.0.1/microsoft.netcore.targets.1.0.1.nupkg",
-        "sha512": "6ed8e75f945a18651066fe9ee31cf6c8257a5974340fe4d262438903c4959a479f4a515a4d1389e6d3d3ab34f09a3c7bc2009aada2e8a7f697b6655a82d3bfc9",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.netcore.targets.1.0.1.nupkg"
     },
     {
         "type": "file",
@@ -428,13 +421,6 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.primitives/4.3.0/microsoft.win32.primitives.4.3.0.nupkg",
-        "sha512": "366f07a79d72f6d61c2b7c43eaa938dd68dfb6b83599d1f6e02089b136fa82bec74b6d54d6e03e08a3c612d51c5596e3535cbc2b29f39b97a827b3e7c79826f0",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.win32.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.registry/5.0.0/microsoft.win32.registry.5.0.0.nupkg",
         "sha512": "471e66567ce59cc86475aece7815d05261264ce114e0c1688ba2551dd51494901fa72dd7a8f74f8e8f0f3dba74af8595f177552f3c06abb4bfce76692197076e",
         "dest": "nuget-sources",
@@ -442,17 +428,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.systemevents/4.5.0/microsoft.win32.systemevents.4.5.0.nupkg",
-        "sha512": "2b64c0af4ee9825fe6fc9f5e777726033c74483e79918b957c11ba48f4481ff10b4e1fc3daa1ab8ce583409a3bafe2d99759ced8d925d14010054b7a4b67b0a9",
+        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.systemevents/6.0.0/microsoft.win32.systemevents.6.0.0.nupkg",
+        "sha512": "5e274ace996c3eba63099ed5116f9dc39f69f684f7c1e7623c28c3c73988b75c67dfcc929a50a761f0222df243dd540720a6e588e91dfa784f81bfce7a893875",
         "dest": "nuget-sources",
-        "dest-filename": "microsoft.win32.systemevents.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/microsoft.win32.systemevents/4.7.0/microsoft.win32.systemevents.4.7.0.nupkg",
-        "sha512": "3dc95211fd597cbeb7b8498e79d58c8dc373767d129252f1858f223fe9228bef56c4dd48e613694581fd197e8c1ec428ec8788a451b9c248e2073c7603c994d4",
-        "dest": "nuget-sources",
-        "dest-filename": "microsoft.win32.systemevents.4.7.0.nupkg"
+        "dest-filename": "microsoft.win32.systemevents.6.0.0.nupkg"
     },
     {
         "type": "file",
@@ -463,31 +442,17 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/netstandard.library/1.6.1/netstandard.library.1.6.1.nupkg",
-        "sha512": "0972dc2dbb4925e896f62bce2e59d4e48639320ee38ad3016dcd485fbd6936a0ed08073ad5eef2a612dff05dfc390f3930fff9e79d87a06070eeb8128277cbd0",
+        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg",
+        "sha512": "83731b662eaf05379a23f8446ef47bbc111349dd4358b7bd8b51383fe9cf637e2fe62f78cea52a0d7bdd582dc6fbbb5837d4a7b1d53dcf37a0ae7473e21ee7b1",
         "dest": "nuget-sources",
-        "dest-filename": "netstandard.library.1.6.1.nupkg"
+        "dest-filename": "newtonsoft.json.13.0.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/10.0.1/newtonsoft.json.10.0.1.nupkg",
-        "sha512": "30e52141f788e37ba9abd42212ffbb6184c340fb446448fdc41e74320a653b55c5fdaba63f47fe4c26081e964499fb226a1249697b7f81d44560b144a05d95c9",
+        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json.bson/1.0.2/newtonsoft.json.bson.1.0.2.nupkg",
+        "sha512": "339d937e19fc2b3b1f99328797dfca8d51ef03acd6c6e61ae3a1d9de576a953e14dcdfe911e1efc2dcb3631fb7fe35672dbe2deb6841db358d5700c69745477e",
         "dest": "nuget-sources",
-        "dest-filename": "newtonsoft.json.10.0.1.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/12.0.3/newtonsoft.json.12.0.3.nupkg",
-        "sha512": "6934665f0479c58bbe996c44f2bf16d435a72f4d92795f0bc1d40cb0bc1358ff0e660ac20b24eabce01ee6145bd553506178e59fbaabd0f2a94b23bfa5c735f5",
-        "dest": "nuget-sources",
-        "dest-filename": "newtonsoft.json.12.0.3.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json.bson/1.0.1/newtonsoft.json.bson.1.0.1.nupkg",
-        "sha512": "5b929ee717a2f724b4963419b93ef95604a9e4ce377823e6e611c07a5bcac86194e1d57b8580a6b7076cc680036ff7b13baa581debbf2248b8dd37583f37c449",
-        "dest": "nuget-sources",
-        "dest-filename": "newtonsoft.json.bson.1.0.1.nupkg"
+        "dest-filename": "newtonsoft.json.bson.1.0.2.nupkg"
     },
     {
         "type": "file",
@@ -512,31 +477,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.diagnostics.tools/4.3.0/runtime.any.system.diagnostics.tools.4.3.0.nupkg",
-        "sha512": "bd257401e179d4b836a4a2f7236a0e303ae997d2453c946bf272036620a0b14e85e5f42c229332930a954655ab4cae359d191a3e3d9746df09535a651367764c",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.diagnostics.tools.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.diagnostics.tracing/4.3.0/runtime.any.system.diagnostics.tracing.4.3.0.nupkg",
-        "sha512": "0b480d21e23c38965222be7fa1e1a0c7e444cebdf400d1db8d3ac609f893b82d78c5d8b271da61808b7b179dd6466a0090bd807fc2d35020f93a00f0213bb436",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.diagnostics.tracing.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization/4.3.0/runtime.any.system.globalization.4.3.0.nupkg",
         "sha512": "3aac1a076212fae7d0ac81d2b5fdf216b064a1d890577307f89c9a4984c239838c3bdfac4dea052027de090704839319231eef49ce542f3e8bb2f85ba23d28dc",
         "dest": "nuget-sources",
         "dest-filename": "runtime.any.system.globalization.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.globalization.calendars/4.3.0/runtime.any.system.globalization.calendars.4.3.0.nupkg",
-        "sha512": "19053b502b7160af6f6b0bc5b334a8d124f77f6b4418993294fb485d0bb318cd6e97cdbda9bf8c9927366288413cad7209c9d8156a5425a6320c453a8804fb3d",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.globalization.calendars.4.3.0.nupkg"
     },
     {
         "type": "file",
@@ -603,24 +547,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.text.encoding.extensions/4.3.0/runtime.any.system.text.encoding.extensions.4.3.0.nupkg",
-        "sha512": "656aa8bd9d7e19534964ac7b8405615f00359779e322d4cfe1f18c132fec4a4f52c5588bfe61cec9966a9142a73315f5d2b9e5a7c524b418364f0322b20961c3",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.text.encoding.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.threading.tasks/4.3.0/runtime.any.system.threading.tasks.4.3.0.nupkg",
         "sha512": "5f37a56f5d6c7fc198c7ef76b822b85284f9d7d1c06583c26a698793ade65da1b273d5fb03c20be1eb91a9c835f7122ad2775f4e51dffb2758fabac2a30f8c23",
         "dest": "nuget-sources",
         "dest-filename": "runtime.any.system.threading.tasks.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.any.system.threading.timer/4.3.0/runtime.any.system.threading.timer.4.3.0.nupkg",
-        "sha512": "c0a1fc3661b4e21f329f88a8d2cbf7152698427778add9f850476fc9abe7cdf9b86df79362d6df025f7e15d53f5eb7937d8ac49bdef13fd9eca973a284929fcf",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.any.system.threading.timer.4.3.0.nupkg"
     },
     {
         "type": "file",
@@ -652,27 +582,6 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.io.compression/4.3.0/runtime.native.system.io.compression.4.3.0.nupkg",
-        "sha512": "bff1f0cac94327014bb07c1ebee06c216e6e4951b1ddaa0c8a753a4a0338be621fd15ec621503490dbca54a75809abc4f420669b33052b28d24d726ac79c9891",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.native.system.io.compression.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.net.http/4.3.0/runtime.native.system.net.http.4.3.0.nupkg",
-        "sha512": "ddd1e5b67545477f7c72b5883666de40e89efb0836d91e7a349e2f3d4ac05ce1125e6add3cb09c39cbdfe7ab7c5dc8fdaeaf6ac25acd92f6de3d8ce2d6db7918",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.native.system.net.http.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.apple/4.3.0/runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
-        "sha512": "23c6a99b323cd71cdcb28c6faa71f099f69ff0972d5125607ae8bbc99ba7c08513571d14526e8c2805ab3a8b70d3d3a6dd76dfa193320393ecb05906ee91f37d",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/runtime.native.system.security.cryptography.openssl/4.3.0/runtime.native.system.security.cryptography.openssl.4.3.0.nupkg",
         "sha512": "ee5d047908b99b776ff9bb54856454b24b09a0f9271b127239543b1f5faa3381a032d9eeb4d813d01b5a4b7d183b6a16250f159fdc450d5314a7eace1550bea3",
         "dest": "nuget-sources",
@@ -691,13 +600,6 @@
         "sha512": "6de9544b4da49f127680cf5b3b4afea96bfcac3293038a1b0a12eea0ad60be368af31ee1dfd66d48d458b40200738c04aa0c71adcc54ae2dddbea2cd50d6f28d",
         "dest": "nuget-sources",
         "dest-filename": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.0/runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg",
-        "sha512": "9929942914071e0ea0944a952ff9ad3c296be39e719a2f4bb3eac298d41829b4468b332fba880ebe242871a02145e1c26dc7660021375d12c7efcae4d200278a",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg"
     },
     {
         "type": "file",
@@ -736,45 +638,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.microsoft.win32.primitives/4.3.0/runtime.unix.microsoft.win32.primitives.4.3.0.nupkg",
-        "sha512": "93e6d3db61f9c2ca2048f25990dda92acd5ec74561e0c776d2c6dd8d1d55128f2c953f33d6832fb6a72bd9edca304a2551085bdeafe6e18af87619c9ba943c32",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.microsoft.win32.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.console/4.3.0/runtime.unix.system.console.4.3.0.nupkg",
-        "sha512": "7c5cbda7d12315fff6b1e036d55ea27140de8b849f1a9705fd2710a00a2b70f06f534eb0d3e3c8ffb019e1a47d96c559ac61d5fc9d840e48f6e56542fdaccb83",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.console.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.diagnostics.debug/4.3.0/runtime.unix.system.diagnostics.debug.4.3.0.nupkg",
         "sha512": "a8ce331953b1f4424aa7f4b6dfedfce9ad138940bc92f332de2bc6d05185830ec6eb832e752f62eaf425f749caadd4ea1789121cb7ed79740fa5868eba55c838",
         "dest": "nuget-sources",
         "dest-filename": "runtime.unix.system.diagnostics.debug.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.io.filesystem/4.3.0/runtime.unix.system.io.filesystem.4.3.0.nupkg",
-        "sha512": "6d4c80aceffac60e1560fda34c5984bbfa2e1bd106bde2c6d3540905cc30c58e6f5f2eaf5703cef5e68e3d25a4b97982193b2db8130a50c622a498e43eb9bdca",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.io.filesystem.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.net.primitives/4.3.0/runtime.unix.system.net.primitives.4.3.0.nupkg",
-        "sha512": "c2a0ecf5c72b226b4776eb6281f00267827d6086a0ad758ebf6e6c64a1c148d2056fe99c87ab4207add5fa67f1db73dd1ed3dca81141fc896be6b6e98795c97e",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.net.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/runtime.unix.system.net.sockets/4.3.0/runtime.unix.system.net.sockets.4.3.0.nupkg",
-        "sha512": "31b62be088315ead04d89f452a6c49a656b88f0668f7dadb2790511675d48705e01c9df24dbed3a0095157875c208ab6e6b5b6afc82bac13e4d6cdd3026f8424",
-        "dest": "nuget-sources",
-        "dest-filename": "runtime.unix.system.net.sockets.4.3.0.nupkg"
     },
     {
         "type": "file",
@@ -806,24 +673,17 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog/2.10.0/serilog.2.10.0.nupkg",
-        "sha512": "9c19964d1126c2e99f546f1da81764644fe39b153e3d8d725473221a6e0855f356776d2f40a8a5d04ece4e420075d5b987650108a4fc9b32b4f56ad3d0792260",
+        "url": "https://api.nuget.org/v3-flatcontainer/serilog/3.1.1/serilog.3.1.1.nupkg",
+        "sha512": "02985d43db0efd5e56b086e0a29af986de381a163a8633ab81a88b6620a3df380afc4506366beba0f214ac8ec37c8d435bdf130285dcde331b14733e62fab8c7",
         "dest": "nuget-sources",
-        "dest-filename": "serilog.2.10.0.nupkg"
+        "dest-filename": "serilog.3.1.1.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog/2.11.0-dev-01367/serilog.2.11.0-dev-01367.nupkg",
-        "sha512": "c89dc8498316f387d822f45feef27a08605b2f5df17138b8f670c8c3a430781ee1933cc5e74bacdc698a7049d7bd21e53fbdd6cba42914da55d19c6d16a7156e",
+        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.console/5.0.1/serilog.sinks.console.5.0.1.nupkg",
+        "sha512": "8f7ab152456edd504e8fce061be144c0c8694f76eb6f61a0284541f23e88a8c292cab487496bb64ce4faec926b53d3923a31cf3ddc874fd9b26f02089a53bb5b",
         "dest": "nuget-sources",
-        "dest-filename": "serilog.2.11.0-dev-01367.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/serilog.sinks.console/4.0.1-dev-00876/serilog.sinks.console.4.0.1-dev-00876.nupkg",
-        "sha512": "4116f4f58c28a34b39521251f4e044041780219b9676945fbbec474e15d482979fadc12f216cc1dbab17815bdae146bb1e30e96d6fbb8d05516923c6882764f1",
-        "dest": "nuget-sources",
-        "dest-filename": "serilog.sinks.console.4.0.1-dev-00876.nupkg"
+        "dest-filename": "serilog.sinks.console.5.0.1.nupkg"
     },
     {
         "type": "file",
@@ -848,122 +708,115 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/shimskiasharp/0.5.16/shimskiasharp.0.5.16.nupkg",
-        "sha512": "bed64051cbbd747cea734d7ad9a430a34a202ac1514d520b898b4147b25fb42f980793722b10c122e68e903f67270ed02c424a694bcca37acfa9fa4b4a499f40",
+        "url": "https://api.nuget.org/v3-flatcontainer/sharphook/5.2.3/sharphook.5.2.3.nupkg",
+        "sha512": "51ca1609dbbf67a2c89dcf3756d8fe0fad54847617506fcc5eaf4f42d4a3f3b24d56c7f3989aacf2260df2e2ee34d0f76d4ebb40eca47ae33a52b5904c0befdf",
         "dest": "nuget-sources",
-        "dest-filename": "shimskiasharp.0.5.16.nupkg"
+        "dest-filename": "sharphook.5.2.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/2.88.1-preview.1/skiasharp.2.88.1-preview.1.nupkg",
-        "sha512": "2af130252fc54b5adc8bbbe558d042fe5c86ca881184865c747fc365c9c557a4ac338c5f4a529ba440ea4fe38e38f754109a5a89cb1ef78392fb3ea3f8203b63",
+        "url": "https://api.nuget.org/v3-flatcontainer/shimskiasharp/1.0.0.13/shimskiasharp.1.0.0.13.nupkg",
+        "sha512": "705bfd34f50270bdc3f6fabca07f7860887cd2da9f3a65bfa29a76bf51773d00110f0f4e953e0eed3fcef63073b5430ef92a90ea0d3d33573853811c333ee466",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.2.88.1-preview.1.nupkg"
+        "dest-filename": "shimskiasharp.1.0.0.13.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/2.88.1-preview.108/skiasharp.2.88.1-preview.108.nupkg",
-        "sha512": "4e283d7b377c8bc6bfd1295fe9e977169447b870a994102f7d24b08b176846a0ca7f01539d75b84c5a8d7a545cd627c838b8194e0c4cd1e5a868396acf1a3483",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/2.88.6/skiasharp.2.88.6.nupkg",
+        "sha512": "5b989f52d9e7efa557bf60e13c1ba329b63670bc66d07bf237e2c8f9bdf28634eeb1e3a735c17c0f7d5b6cb8e290bda0b139540a8b0b99343367f9710f81dffd",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.2.88.1-preview.108.nupkg"
+        "dest-filename": "skiasharp.2.88.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.harfbuzz/2.88.1-preview.1/skiasharp.harfbuzz.2.88.1-preview.1.nupkg",
-        "sha512": "c9286331f2b32cb73e2000f544f66fb4e28a004cd92b486127c7aa2e77adfdbe59a0cc109f8cefab0950c812ddf15b2df34e1c56b59f5673c1a520e070b4db04",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp/2.88.7/skiasharp.2.88.7.nupkg",
+        "sha512": "4a54db99f245742231c208c455b6f29a96ee79672e3eab7f7dbd6b352aeaa3b6a87d6946017d899887b4026d5b4ceca6297230dbaacf1725a9726f796ee72303",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.harfbuzz.2.88.1-preview.1.nupkg"
+        "dest-filename": "skiasharp.2.88.7.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/2.88.1-preview.1/skiasharp.nativeassets.linux.2.88.1-preview.1.nupkg",
-        "sha512": "6153cd7b79775918e912da027e0829f1c1b71e2a0067d7731008bad71819c969d5e7fb3b59fe553cc556fa4c6ca6655c7bb1ec5a4872152083e925f04845c1ba",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.harfbuzz/2.88.6/skiasharp.harfbuzz.2.88.6.nupkg",
+        "sha512": "9f8b6448ee3a24af51fac0aaf5a55f5824e40068a1bc2a1a9f1ae646f8b672f9ab22a2e1a306284f01c496fe05e1a3c7e0657a17d02e07ae042c132fb2a3edd7",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.linux.2.88.1-preview.1.nupkg"
+        "dest-filename": "skiasharp.harfbuzz.2.88.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/2.88.1-preview.108/skiasharp.nativeassets.linux.2.88.1-preview.108.nupkg",
-        "sha512": "e60ed0a574bb1d76057b1ec7c71d223a1e8c4d7722095979d9f3cef7706b8a084b302aeb5bb81c79f5daaf886ad48b229e0826388353abefd0b45487a18bb48b",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/2.88.3/skiasharp.nativeassets.linux.2.88.3.nupkg",
+        "sha512": "544ef5b9e0a9d97214e743a93b0147364a767e5a31374dfb8dcd069f14a424b54db56fce85f28d14157b7493930d7408f99afbc383994cd2243e9bb27bf57813",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.linux.2.88.1-preview.108.nupkg"
+        "dest-filename": "skiasharp.nativeassets.linux.2.88.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/2.88.1-preview.1/skiasharp.nativeassets.macos.2.88.1-preview.1.nupkg",
-        "sha512": "0e70fd1833f43b72ed69106d54e449ef71ecc2ad7079b6c6403a3d2d5d979191f77ba340dc9b577cdf88f51e4f31232bf42dfd645a9a5cd110732504c568228c",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/2.88.7/skiasharp.nativeassets.linux.2.88.7.nupkg",
+        "sha512": "4f7db81ee10c07db2d824813dacf0189bafd0e30dcb3087ffebfab9927976f67c2cde71c1a22345718d83fa32193303cf9d578e7d9d6fa30964ca1bf8c8127d7",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.macos.2.88.1-preview.1.nupkg"
+        "dest-filename": "skiasharp.nativeassets.linux.2.88.7.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/2.88.1-preview.108/skiasharp.nativeassets.macos.2.88.1-preview.108.nupkg",
-        "sha512": "0ba49dc28fca165f60a842ce7323b773b52847ff4c1af054a3da74892b7132246fe2dfdacc2527d044522712c20d8bdf4b158128d88f9b9156a677eb60375e5e",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/2.88.6/skiasharp.nativeassets.macos.2.88.6.nupkg",
+        "sha512": "a9abf36aadd48c8a9e0ea35f95acdbe3a354091b37f97c1df97499213894f662e798687bad36da71fcfa05b6fdbc68aaff2e8a8ddbeec4ca2820bfe7cf5a9ed7",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.macos.2.88.1-preview.108.nupkg"
+        "dest-filename": "skiasharp.nativeassets.macos.2.88.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.webassembly/2.88.1-preview.1/skiasharp.nativeassets.webassembly.2.88.1-preview.1.nupkg",
-        "sha512": "8219d9ea3f2fea1daf62c3dd0d172ce9a121b609648a77d1142234c6bc8eef6fffef285ce7c8c8688e3d114aa3580309939796aea298be1ef5ba384474cc18dc",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/2.88.7/skiasharp.nativeassets.macos.2.88.7.nupkg",
+        "sha512": "52ce6db283f366aa8f469f80564586c4d09fdbdbc4442fe24bf159fca803b92bdf2e209f537f9b30948a289e063fced46232b44a5c686168e33322e6314f1d5e",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.webassembly.2.88.1-preview.1.nupkg"
+        "dest-filename": "skiasharp.nativeassets.macos.2.88.7.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.webassembly/2.88.1-preview.108/skiasharp.nativeassets.webassembly.2.88.1-preview.108.nupkg",
-        "sha512": "10adc0bb36530b690c784407524ef5f6298dbd5a21fc32beb7be0fd4004905e2d775bd1edde55b7efbfd6a97bbf7660175ed6ca7fbf1ae8ecea008fd8bb4bde7",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.webassembly/2.88.3/skiasharp.nativeassets.webassembly.2.88.3.nupkg",
+        "sha512": "243ef57a09f88cfa086acd74419ba7c39b041cd113d4de2e72192ca8a40d7ecc74b5ab60f6a80195b89b7dff249650d48f44cbd25450b264cde79a7034600faa",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.webassembly.2.88.1-preview.108.nupkg"
+        "dest-filename": "skiasharp.nativeassets.webassembly.2.88.3.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/2.88.1-preview.1/skiasharp.nativeassets.win32.2.88.1-preview.1.nupkg",
-        "sha512": "91e2291dded613cbdf3242ba48a728aba1f1d8e428536b974ddd1ba96950431116c83fe20138244af6e86e40a783d67c1784ec270c155d9af3a2024ae25d4b10",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.webassembly/2.88.7/skiasharp.nativeassets.webassembly.2.88.7.nupkg",
+        "sha512": "bee40d258b80a0ea1e849d77c8fd7d594643ac24c666aa9575473462009cdfd1c33e1d4148848187bebc239ced3eb37652b3c7558a597c6959604aabf44498a4",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.win32.2.88.1-preview.1.nupkg"
+        "dest-filename": "skiasharp.nativeassets.webassembly.2.88.7.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/2.88.1-preview.108/skiasharp.nativeassets.win32.2.88.1-preview.108.nupkg",
-        "sha512": "46a101fb62e66a43c81bc69ee073ccaeab38e0ef764806f03b7812dbd6364dd1433752518a44d6adef100190b959a29462f5b60a258243d40994a25fc56b8607",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/2.88.6/skiasharp.nativeassets.win32.2.88.6.nupkg",
+        "sha512": "02087547abd840806105270d43cc3a61b417f331192498571e2cff1382dfd15a1bf6b1552610c7579bf06da69b6e9a80b042ae980d0475da8acf3f7dab7334f4",
         "dest": "nuget-sources",
-        "dest-filename": "skiasharp.nativeassets.win32.2.88.1-preview.108.nupkg"
+        "dest-filename": "skiasharp.nativeassets.win32.2.88.6.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/svg.custom/0.5.16/svg.custom.0.5.16.nupkg",
-        "sha512": "002cb9e5d13a0d69c2cd8b36161a5d6173fcfc177739751c381eaae15a5f00834e4e6047f6af379a2a22b14fd75783449293f0da9031b1b27a0f0541a5db334a",
+        "url": "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/2.88.7/skiasharp.nativeassets.win32.2.88.7.nupkg",
+        "sha512": "3476a2b19745b1ece35858a8534a02f7196ea0b30971d96b4d6219d2e8de4068f9ad83b5e0527519facd88fc64b46c69ac43b45a0f26c01e36885c3c54872324",
         "dest": "nuget-sources",
-        "dest-filename": "svg.custom.0.5.16.nupkg"
+        "dest-filename": "skiasharp.nativeassets.win32.2.88.7.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/svg.model/0.5.16/svg.model.0.5.16.nupkg",
-        "sha512": "a05c6d960736459751b0045f7a4ab0a3f6f4da4b7bd5f249b158157a4279bb3d56532d951b4be72df7859909f0344c827a2f9456b0894b73437408e44f9e57b5",
+        "url": "https://api.nuget.org/v3-flatcontainer/svg.custom/1.0.0.13/svg.custom.1.0.0.13.nupkg",
+        "sha512": "45343585e56c4d72c3be8219184f5cdd13ec5b79fdecd3ba2bd3850d131e9adacf4de798d5782fadf88b468e98635e4bcb7f7a0320092a10d1d46698a51793f3",
         "dest": "nuget-sources",
-        "dest-filename": "svg.model.0.5.16.nupkg"
+        "dest-filename": "svg.custom.1.0.0.13.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/svg.skia/0.5.16/svg.skia.0.5.16.nupkg",
-        "sha512": "6a26a29418a4ea236302c28d199ab4a1478a2ec22031390a57faecd4dea5369a1767c723ad2e0bfffb684c642447d59c23a218d9443f51dae187e14525bfa93d",
+        "url": "https://api.nuget.org/v3-flatcontainer/svg.model/1.0.0.13/svg.model.1.0.0.13.nupkg",
+        "sha512": "680a4103bc1763c59b0095d80b3171628746d1b7eee9baec16345d80af863750852532b24e0c410dbaa2a68a3402dfc5fcca766c5980786e66b646a7358f0877",
         "dest": "nuget-sources",
-        "dest-filename": "svg.skia.0.5.16.nupkg"
+        "dest-filename": "svg.model.1.0.0.13.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.appcontext/4.3.0/system.appcontext.4.3.0.nupkg",
-        "sha512": "0d6ea63006304708feae2cc0590d2cdd99327b682210822bb2803ac842fdf4d8d57170d7947c006eec4b5687c942768478a7ec109745472f3946d230732483e8",
+        "url": "https://api.nuget.org/v3-flatcontainer/svg.skia/1.0.0.13/svg.skia.1.0.0.13.nupkg",
+        "sha512": "da109cb14d434aced99957b207c9adca01a7b91eab43a109ddf1690df273e848e34d289e7a96d6e5f5bfcb1ae694709b27a4fa99da0ecf1fb649a5ef1e7428bf",
         "dest": "nuget-sources",
-        "dest-filename": "system.appcontext.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.buffers/4.3.0/system.buffers.4.3.0.nupkg",
-        "sha512": "3dcbf66f6edf7e9bb4f698cddcf81b9d059811d84e05c7ac618b2640efed642f089b0ef84c927c5f58feffe43bb96a6bcf4fec422529b82998b18d70e4648cbe",
-        "dest": "nuget-sources",
-        "dest-filename": "system.buffers.4.3.0.nupkg"
+        "dest-filename": "svg.skia.1.0.0.13.nupkg"
     },
     {
         "type": "file",
@@ -974,13 +827,6 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.concurrent/4.3.0/system.collections.concurrent.4.3.0.nupkg",
-        "sha512": "35c1aa3e636216fe5dc2ebeb504293e69ad6355d26e22453af060af94d8279faa93bdcfe127aecb0b316c7e7d9185bcac72e994984efdb7f2d8515f1f55cf682",
-        "dest": "nuget-sources",
-        "dest-filename": "system.collections.concurrent.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.collections.immutable/1.5.0/system.collections.immutable.1.5.0.nupkg",
         "sha512": "4f95c64257078443bbe50c77f061825033dd9389ffef2ad1993832e32733cc957c6a53c76b13d4e794c10b6505ae4438d9bbb7e2c64f7cad1d53e9d665438424",
         "dest": "nuget-sources",
@@ -988,59 +834,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.nongeneric/4.3.0/system.collections.nongeneric.4.3.0.nupkg",
-        "sha512": "dc6abfe778b3ea08e99f50b79112a51728e689f353b082234351b9f5b1be4b601a0b6d38a04c2138d05b5bdd83d6f3d91b53ee86ed119225c15e4683c38bf98c",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.configuration.configurationmanager/6.0.0/system.configuration.configurationmanager.6.0.0.nupkg",
+        "sha512": "de58cb928d6303a16301fd7aa8edac379dfe6c47e6d80b21665f92bab9dd5ff52b3e244cf6df0f945f1c72e71c92337561dbf2752fc3324174a8c9ecc70c3247",
         "dest": "nuget-sources",
-        "dest-filename": "system.collections.nongeneric.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.collections.specialized/4.3.0/system.collections.specialized.4.3.0.nupkg",
-        "sha512": "c7a257cbda812d6c0c44b29d8bb5cc4f5cf2d3cb81574eb1dc94a7efde980ac26c5ffadb7cc3521fe7b19437766a046c83cbf2e7ea59a36435c288add8142b57",
-        "dest": "nuget-sources",
-        "dest-filename": "system.collections.specialized.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.componentmodel/4.3.0/system.componentmodel.4.3.0.nupkg",
-        "sha512": "7c638ac92a132e1553a089c6a711ffb7431b22fecca322ce748d6684ae2baaf161bab2f71704750bd15ec6fda11e795f2ab8491ac769b89341bde77aa9212d59",
-        "dest": "nuget-sources",
-        "dest-filename": "system.componentmodel.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.componentmodel.annotations/4.5.0/system.componentmodel.annotations.4.5.0.nupkg",
-        "sha512": "7f5029507196abf9490bc3d913b26a6c0ded898ed99e06503b699b61f086d0995055552aaa654c032d1f32f03012e1badfd338ec42dd3fa3d0c5ce4e228ea2e8",
-        "dest": "nuget-sources",
-        "dest-filename": "system.componentmodel.annotations.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.componentmodel.primitives/4.3.0/system.componentmodel.primitives.4.3.0.nupkg",
-        "sha512": "ab26d413abce9cfc31b860765d91b21d4048976016d853ce8969f7ba79c039d8846b3c4e2986530f20b62dcb23ff0a769ae5ee37fc078d69eaa962832f2035ef",
-        "dest": "nuget-sources",
-        "dest-filename": "system.componentmodel.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.componentmodel.typeconverter/4.3.0/system.componentmodel.typeconverter.4.3.0.nupkg",
-        "sha512": "0a2b2f3c25de4a6429c6cb9fbb37409e86168921ea71ec58889912742e39e1b67f5cbe764affc3580aa0ef167c7f73a55332a0abf7b043e89185293029d8b087",
-        "dest": "nuget-sources",
-        "dest-filename": "system.componentmodel.typeconverter.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.configuration.configurationmanager/4.7.0/system.configuration.configurationmanager.4.7.0.nupkg",
-        "sha512": "0047bbc7777fa368f0a6f352bf994b44bccb1bef81ef7037065eb976977cffe99e6c964407a7d30961f3a8213dd52cf44a81f47b6fc7d698ea5d54444618f6af",
-        "dest": "nuget-sources",
-        "dest-filename": "system.configuration.configurationmanager.4.7.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.console/4.3.0/system.console.4.3.0.nupkg",
-        "sha512": "a08a684a583c9b3278ce32be1007dae495f9d87254666392f794ef1203079f333cd7d388c28944ffa36fb49f0c8bb21f42c70f6e1d7c1c03920df6d0d1130c82",
-        "dest": "nuget-sources",
-        "dest-filename": "system.console.4.3.0.nupkg"
+        "dest-filename": "system.configuration.configurationmanager.6.0.0.nupkg"
     },
     {
         "type": "file",
@@ -1051,45 +848,17 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.diagnosticsource/4.3.0/system.diagnostics.diagnosticsource.4.3.0.nupkg",
-        "sha512": "8f54df5ff382b6650e2e10d1043863a24bf49ff0714e779e837cd7073e46fb2635bcfcdcf99d7c4a9d95f35ebffd86ab0ca068305f4b245072e08303b917b34d",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.eventlog/6.0.0/system.diagnostics.eventlog.6.0.0.nupkg",
+        "sha512": "40103d5b7cb2b41c7cafca629c112c5526bb773d11367ca62918d8864fba8dac2b48151f37671bcf50499d8f8b268489ee1cade2fb8947cc06e205a1fac6784c",
         "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.diagnosticsource.4.3.0.nupkg"
+        "dest-filename": "system.diagnostics.eventlog.6.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tools/4.3.0/system.diagnostics.tools.4.3.0.nupkg",
-        "sha512": "164d6977e721cbceb44ede7bfd75b03b8d9771e0426aefa5d40c71867e964092fdc6a6808bcbc5559ed73ec2c532ca657d6476af79a49ca3ad879b8366f13d90",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.drawing.common/6.0.0/system.drawing.common.6.0.0.nupkg",
+        "sha512": "d61f0a3e01c3eac15f13fc1ba04a2c7ce4eac956400b2faa361fecabd3836d49d5bd344f3985ee3d94cdc3f6a72b8e07e423cdb2965b4f5ca2222b5de32988e4",
         "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.tools.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tracesource/4.3.0/system.diagnostics.tracesource.4.3.0.nupkg",
-        "sha512": "0655962fdabf1ca334281cee3923aa7211606b932a9ef90ae666fe214edfe1e7089d2ca0865b3047789bde7c30d6bb8198baed748e5ca02041d87d8096d4c5c8",
-        "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.tracesource.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.diagnostics.tracing/4.3.0/system.diagnostics.tracing.4.3.0.nupkg",
-        "sha512": "d0a5d30e261cd45b7dfab02b7ffbd76b64e0c9b892ed826ea61481c983c0208b05b69981cd79e91cd4e5811e1cd4c3cea06a1afce05811ece58be5e4c20169ea",
-        "dest": "nuget-sources",
-        "dest-filename": "system.diagnostics.tracing.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.drawing.common/4.5.0/system.drawing.common.4.5.0.nupkg",
-        "sha512": "b988b161b074bf3c526dcf41ee3cf0c1403c529a1d6a3de0d99367444596eb3a01c3d0e5b7396d7046b5834238bba011a95274b78137c89016c3987682f26585",
-        "dest": "nuget-sources",
-        "dest-filename": "system.drawing.common.4.5.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.drawing.common/4.7.0/system.drawing.common.4.7.0.nupkg",
-        "sha512": "5ca48fb9622fbe9c7c52e93902879af730c356bb276b65570d774f8786c59d75e6ad993ce2af477f9611a8e97967c12373afd0a8cb8a9f1d6e63505da4bed334",
-        "dest": "nuget-sources",
-        "dest-filename": "system.drawing.common.4.7.0.nupkg"
+        "dest-filename": "system.drawing.common.6.0.0.nupkg"
     },
     {
         "type": "file",
@@ -1107,20 +876,6 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.calendars/4.3.0/system.globalization.calendars.4.3.0.nupkg",
-        "sha512": "e97190231402b393774b925efc02a2bfa41d1d117a17fb87da6e399f5234546962767e9cd8f39970efa408e4f453cd1e6751a2a61e366bc97406e1b0b8a4be86",
-        "dest": "nuget-sources",
-        "dest-filename": "system.globalization.calendars.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.globalization.extensions/4.3.0/system.globalization.extensions.4.3.0.nupkg",
-        "sha512": "a4d360003f95e0c31edf39c0b91e1c73850a60ac5d0032b17db888a3c7d7134cef9acd97219d14174ad213b7c044f49b364cc5720073ebfcb6e1bf6e4ec24ce5",
-        "dest": "nuget-sources",
-        "dest-filename": "system.globalization.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.io/4.3.0/system.io.4.3.0.nupkg",
         "sha512": "bfca5a21e3e1986b9765b13dc6fbcd6f8b89e4c1383855d1d7ef256bf1bf2f51889769db5365859dd7606fbf6454add4daeb3bab56994ffb98fd1d03fe8bc1e6",
         "dest": "nuget-sources",
@@ -1128,31 +883,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.compression/4.3.0/system.io.compression.4.3.0.nupkg",
-        "sha512": "f540ee51a3bb6941cdfbaace9a9738d7f7986a2f94770db61f45a88ecb7ef36b571d4c07417dc89cdbe9655a262b7cc599b0a4b78effea91819e186121b44807",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.io.pipelines/6.0.0/system.io.pipelines.6.0.0.nupkg",
+        "sha512": "c5983b4510bc8ae4116133ffb9b280fe61d99d47ef52dd78e5bfd03e090901896d5d5fd738dae57006b971840a4d9422bded33ddefa5e927d75d309ef1f70dea",
         "dest": "nuget-sources",
-        "dest-filename": "system.io.compression.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.compression.zipfile/4.3.0/system.io.compression.zipfile.4.3.0.nupkg",
-        "sha512": "1860634672767f818f0192ec2b2750693f0d39390f3b7d400cc6fd4f6e74a5cbed27bf49e5980ec85ff3e161c30f6190f700e339a1040c1699b87eb4aa7b6792",
-        "dest": "nuget-sources",
-        "dest-filename": "system.io.compression.zipfile.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem/4.3.0/system.io.filesystem.4.3.0.nupkg",
-        "sha512": "4fb581d6f85b9529a091a0e974633752aa39e50b2be6c8a9e5eca8c2bc225cea07064ccec7778f77df9987deebf4dccec050b1a97edac0ee9107142e6a8ee7ee",
-        "dest": "nuget-sources",
-        "dest-filename": "system.io.filesystem.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.io.filesystem.primitives/4.3.0/system.io.filesystem.primitives.4.3.0.nupkg",
-        "sha512": "5885953d09582cffd973d23a21a929064d72f2bc9518af3732d671fffcc628a8b686f1d058a001ee6a114023b3e48b3fc0d0e4b22629a1c7f715e03795ee9ee5",
-        "dest": "nuget-sources",
-        "dest-filename": "system.io.filesystem.primitives.4.3.0.nupkg"
+        "dest-filename": "system.io.pipelines.6.0.0.nupkg"
     },
     {
         "type": "file",
@@ -1177,38 +911,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.4/system.memory.4.5.4.nupkg",
-        "sha512": "8ece5491eb0fe332bc190f40cf76b3beee0c5f996325034861be221fdb0ff02fd59e4f7020b3c4a1f29a457f76ff76c4c95d46d38555e4f48c7a3bf172d87966",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.memory/4.5.5/system.memory.4.5.5.nupkg",
+        "sha512": "e8c8e536c97b94ac3443c940b30dad43cf6e97dc7a8c3d989371048fe74e168606384f5e0143bdc0d86f7783bf9fdee8417964cb3a8a5d752713e90b125172dc",
         "dest": "nuget-sources",
-        "dest-filename": "system.memory.4.5.4.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.http/4.3.0/system.net.http.4.3.0.nupkg",
-        "sha512": "e8105ce8151aee95852fb29423f73cc1bd7c2286d36474ed7102a4b31248e45f434434a176d3af0442738398c96c5753965ee0444fb9c97525abbd9c88b13e41",
-        "dest": "nuget-sources",
-        "dest-filename": "system.net.http.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.nameresolution/4.3.0/system.net.nameresolution.4.3.0.nupkg",
-        "sha512": "40d39e131fe7a392e58e9f58b516b5db88383de91c05b771f5e509acf46cc874271e90623d327ab039003ab8f2714144694390261278de324e1aee228a828ab4",
-        "dest": "nuget-sources",
-        "dest-filename": "system.net.nameresolution.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.primitives/4.3.0/system.net.primitives.4.3.0.nupkg",
-        "sha512": "9f7fdece330a81f3312ea7c804927852413bee2c929f3066b736993803df47cc0692fbca236c222bf19dc8f59b42f54f2a4c00da9a4d624e458da5874d127ce6",
-        "dest": "nuget-sources",
-        "dest-filename": "system.net.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.net.sockets/4.3.0/system.net.sockets.4.3.0.nupkg",
-        "sha512": "e32ed9518e9630e99edcf1963c3d0e7047ea8252853c9260eb5403a4206170ae28fd27eb239f39da4d2db766f830b3ebdc9e4da2e697be20241d928082200955",
-        "dest": "nuget-sources",
-        "dest-filename": "system.net.sockets.4.3.0.nupkg"
+        "dest-filename": "system.memory.4.5.5.nupkg"
     },
     {
         "type": "file",
@@ -1251,13 +957,6 @@
         "sha512": "be45051467a36ab965410f112a475fb81510a5595347d1cc0c46b028e0436a339218dd3c073f048c2d338b67dc13b45742290b6c46f55982503f74a8f2698818",
         "dest": "nuget-sources",
         "dest-filename": "system.reflection.emit.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.reflection.emit/4.7.0/system.reflection.emit.4.7.0.nupkg",
-        "sha512": "10c0325b993a31d993c58adeee5f1c6fd7ff66173bf22bf0d295d29bfb30f0e01ec3042aceac5e245bb62d8fbfed63ce02adf74e04cf55811e0cf3d541b897a9",
-        "dest": "nuget-sources",
-        "dest-filename": "system.reflection.emit.4.7.0.nupkg"
     },
     {
         "type": "file",
@@ -1310,13 +1009,6 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime/4.1.0/system.runtime.4.1.0.nupkg",
-        "sha512": "4b05eb68bb485846707c4fe3393f9616d3ffb6c5f62a121d81142ddf7d0241c931fe96d193b7bf02281a9368458e0764466766557cfa9709035dc76d8fdd7706",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.4.1.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.runtime/4.3.0/system.runtime.4.3.0.nupkg",
         "sha512": "92ab2249f08073cfafdc4cfbd7db36d651ad871b8d8ba961006982187de374bf4a30af93f15f73b05af343f7a70cbd484b04d646570587636ae72171eb0714fb",
         "dest": "nuget-sources",
@@ -1324,24 +1016,17 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.5.2/system.runtime.compilerservices.unsafe.4.5.2.nupkg",
-        "sha512": "84c91d5b192cca942515707b25a9907a00ec73110040ee051ddfe5c3fce549953d7598008a3eb9c630ab5deaf5f37c2fa0d033262739cf38e3da873dfdd9685a",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.compilerservices.unsafe.4.5.2.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.6.0/system.runtime.compilerservices.unsafe.4.6.0.nupkg",
-        "sha512": "fb9cd0d29dd0a1215894b53d1bd7fa5e7f16922ebc204128293e71c4af1e80aaaff31515d8a919736be969eeeba8070860587e11d9a76c45fc1e13e1e67581cd",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.compilerservices.unsafe.4.6.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/4.7.0/system.runtime.compilerservices.unsafe.4.7.0.nupkg",
         "sha512": "14c154122872d3929f4f691aa2cb8db78f62b8b6e18b278b39a53d128d93b5cc59be330fa9b6b4613c81f9acfe004f1c97f2f815df753a8b97628c17dd543605",
         "dest": "nuget-sources",
         "dest-filename": "system.runtime.compilerservices.unsafe.4.7.0.nupkg"
+    },
+    {
+        "type": "file",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.compilerservices.unsafe/6.0.0/system.runtime.compilerservices.unsafe.6.0.0.nupkg",
+        "sha512": "d4057301be4ec4936f24b9ce003b5ec4d99681ab6d9b65d5393dd38d04cdec37784aaa12c1a8b50ac3767ed878dae425749490773fec01e734f93cf1045822b3",
+        "dest": "nuget-sources",
+        "dest-filename": "system.runtime.compilerservices.unsafe.6.0.0.nupkg"
     },
     {
         "type": "file",
@@ -1366,45 +1051,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.interopservices.runtimeinformation/4.3.0/system.runtime.interopservices.runtimeinformation.4.3.0.nupkg",
-        "sha512": "6f4905329a3cc9e62d274c885f275ee31c5af57a6c9fd1a5080d039cb748e0277bef3dc8ce42863cac78365084e00a032279bf3d2b7254a49f3fb1566a29ad1b",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.interopservices.runtimeinformation.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.loader/4.3.0/system.runtime.loader.4.3.0.nupkg",
         "sha512": "1ba5a6bc023dc8e122e46396b594f7fa92561d719a6ade7da99290ed9ef97c6a5a72594f98b8b334566f6578f70b2b12c8c91006c9b9d1bf714ccff1f4bdf209",
         "dest": "nuget-sources",
         "dest-filename": "system.runtime.loader.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.numerics/4.3.0/system.runtime.numerics.4.3.0.nupkg",
-        "sha512": "3e347faa8e7ec484d481e53b1c219fe1ce346ae8278a214b4508cf0e233c1627bd9c6c6c7c654e8c1f4143271838ddd9593f63a1043577ad87c40e392af7fd34",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.numerics.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.serialization.formatters/4.3.0/system.runtime.serialization.formatters.4.3.0.nupkg",
-        "sha512": "5b852aca669b8826f5c71b8aaeca490b30875bde55650dc60a6ce90d81ef271554bcf636b22c14e00e6b3eef0445a44f52f41168ede3757f06afea1ee58e0908",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.serialization.formatters.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.runtime.serialization.primitives/4.3.0/system.runtime.serialization.primitives.4.3.0.nupkg",
-        "sha512": "fcf73baadf5675029e91f2e6e4a71c305eece3671ef69f49440f9c6da160d7b33f0a73923d652f2987f7668093f74ed83de72b185de2ce6ec6b37c6e821217ae",
-        "dest": "nuget-sources",
-        "dest-filename": "system.runtime.serialization.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/4.7.0/system.security.accesscontrol.4.7.0.nupkg",
-        "sha512": "464255881cc1ad9a0df09eaa1ea926c75df4196537a1c5adb180665ec21f8da627d00c778601ee05894ee745664374a38f0369778c98b29cbe236aa70deab5ae",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.accesscontrol.4.7.0.nupkg"
     },
     {
         "type": "file",
@@ -1415,94 +1065,24 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.claims/4.3.0/system.security.claims.4.3.0.nupkg",
-        "sha512": "ab72b90801f6c051a2b31645448eebfca74642b3cfa1d51f80e21a0d0d7ad44d3366dea139347e2852781b7f3bae820df16c3eb188a2c96244df05394ed72c86",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/6.0.0/system.security.accesscontrol.6.0.0.nupkg",
+        "sha512": "64a36a103b954ab4b7e8a76c0e876579bd484c308e444c2d915fb9a0fd05ad63614501ed235c544afc9b431cb8a4cf0f0715b8ed414e85958e6d68579168fb45",
         "dest": "nuget-sources",
-        "dest-filename": "system.security.claims.4.3.0.nupkg"
+        "dest-filename": "system.security.accesscontrol.6.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.algorithms/4.3.0/system.security.cryptography.algorithms.4.3.0.nupkg",
-        "sha512": "7641d70c2ba6f37bf429d5d949bda427f078098c2dcb8924fd79b23bb22c4b956ef14235422d8b1cc5720cbbcc6cfee8943d5ff87ce7abf0d54c5e8bce2aa5e2",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.protecteddata/6.0.0/system.security.cryptography.protecteddata.6.0.0.nupkg",
+        "sha512": "489b5dab0abfadfb8bc2d0437de83a1447918071949440e766db701c81c3518de6a38a3e0f699706b06d591ab5393c7bc0b2eaa81c15bff156339248e6c35730",
         "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.algorithms.4.3.0.nupkg"
+        "dest-filename": "system.security.cryptography.protecteddata.6.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.cng/4.3.0/system.security.cryptography.cng.4.3.0.nupkg",
-        "sha512": "6272273414eaa777e78dca1b5ecbbdf65e9659908082aea924df0975e71f4c1b47f85617edf90ead57078c29513a160ca62f123be9f9f339dfb9c9386844f5ea",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.security.permissions/6.0.0/system.security.permissions.6.0.0.nupkg",
+        "sha512": "d4f2172cc3b164f104fa2e3a330b62f2a15f50e050a91659db5728f28d4d5d6ca8660eec3a4f922090181a54bc1e9f6634ca49750398360727d1bc59db620278",
         "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.cng.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.csp/4.3.0/system.security.cryptography.csp.4.3.0.nupkg",
-        "sha512": "43317591747a18f52f683187e09adfe0e03573e6dac430bf3ba13f440cdb1c7bb1f9205369d5f3b2a0f3fdf9604d5ba1e6d94a899a25d2c533e453338578f351",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.csp.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.encoding/4.3.0/system.security.cryptography.encoding.4.3.0.nupkg",
-        "sha512": "5c26add23e63542f37506f5fa1f72e8980f03743d529cd8e583d1054b8d8a579fb773fa035a00d9073db84db6be4f47cac340d1ebc6d23dd761dbdbd600075e0",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.encoding.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.openssl/4.3.0/system.security.cryptography.openssl.4.3.0.nupkg",
-        "sha512": "64530a19489730f873f8c68e6b245135ea260c02d68591880261768358d0145795132ba5ee877741822ff05dcd0c61edca27696ef99e8f9302a21cadf3b1329f",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.openssl.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.primitives/4.3.0/system.security.cryptography.primitives.4.3.0.nupkg",
-        "sha512": "5ad8273f998ebb9cca2f7bd03143d3f6d57b5d560657b26d6f4e78d038010fb30c379a23a27c08730f15c9b66f4ba565a06984ec246dfc79acf1a741b0dd4347",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.primitives.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.protecteddata/4.7.0/system.security.cryptography.protecteddata.4.7.0.nupkg",
-        "sha512": "a55ae6196de1e659228213282b1e5b640c8d8337281f914287960bb2057b14aa8e2efa623f789453beae9accbbc8cd6e88022bf9571667f0cd9cc329c2ce3e37",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.protecteddata.4.7.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.cryptography.x509certificates/4.3.0/system.security.cryptography.x509certificates.4.3.0.nupkg",
-        "sha512": "318d86ab5528e2b444ec3e4b9824c1be82bb93db513eab34b238e486f886c4d74310ed82c2110401fe5cd790e4d97f4a023a0b2d5c2e29952d3fd02e42734d00",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.cryptography.x509certificates.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.permissions/4.7.0/system.security.permissions.4.7.0.nupkg",
-        "sha512": "9c86c3b424218d618d3028cd4e16e2b93140ee4e082d989a4b234941eb2822e5db9cd42165157e1de7a476482a94b947bc16ad9603888b3a926f63579733b684",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.permissions.4.7.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal/4.3.0/system.security.principal.4.3.0.nupkg",
-        "sha512": "db8a1ed0d189637d9ef83147550ce5da890cf6ec189a7d006ba9de86ab55679e7f025e18bdaed2dc137ddf82a7e6a0131fb4d54d4264831862b1d7c5ee62837e",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.principal.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/4.3.0/system.security.principal.windows.4.3.0.nupkg",
-        "sha512": "66c1d5a9d649b964e1653fa2cd41d8f80515b7cd727fcd7f0890552070da1099ecd1032560f259a108e0d1d6a6da23fa07bc5c922f426a91f33b667f7c004019",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.principal.windows.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/4.7.0/system.security.principal.windows.4.7.0.nupkg",
-        "sha512": "f30a16d34c8792db60b2240363a8b200cab28bc2c7441405cf19abf71dbf5fb0bf3bd1cbec4d9b5eb4cf73ec482e4505d08d80afdef00b2b4b3bb56d6d4cae96",
-        "dest": "nuget-sources",
-        "dest-filename": "system.security.principal.windows.4.7.0.nupkg"
+        "dest-filename": "system.security.permissions.6.0.0.nupkg"
     },
     {
         "type": "file",
@@ -1520,24 +1100,17 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/5.0.0/system.text.encoding.codepages.5.0.0.nupkg",
-        "sha512": "4f32c801b3dc8b3d287c17310e8eaecbb7d3d0e311e39e1c428439fea7276860febc38422a61abc93d3cbbcd97bf511835b316553e931e04f6333a80629dc746",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.codepages/8.0.0/system.text.encoding.codepages.8.0.0.nupkg",
+        "sha512": "77dadf6b1a73eeefb50507a6d76f5e3a20e0ae7d3f550c349265ae4e0d55f0ae4f0ef1b41be08dd810798a8e01dbba74e2caac746b5158b8e23d722523d473ed",
         "dest": "nuget-sources",
-        "dest-filename": "system.text.encoding.codepages.5.0.0.nupkg"
+        "dest-filename": "system.text.encoding.codepages.8.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encoding.extensions/4.3.0/system.text.encoding.extensions.4.3.0.nupkg",
-        "sha512": "e648c5dc781e35cf00c5cc8e7e42e815b963cf8fb788e8a817f9b53e318b2b42e2f7a556e9c3c64bf2f6a2fd4615f26ab4f0d4eb713a0151e71e0af3fe9c3eed",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.text.encodings.web/6.0.0/system.text.encodings.web.6.0.0.nupkg",
+        "sha512": "0f26afeeaa709ea1f05ef87058408dd9df640c869d7398b2c9c270268ddf21a9208cd7d2bfa1f7fbd8a5ceab735dd22d470a3689627c9c4fadc0ea5fe76237fa",
         "dest": "nuget-sources",
-        "dest-filename": "system.text.encoding.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.json/4.7.0/system.text.json.4.7.0.nupkg",
-        "sha512": "d6ad50bdc50a094b0e0d08cba8d708e77e974b11102b64e618bc8e324ef7288015f91b44ceddd845d974b138277c4a45aa27c32a4aeb0a918fa65929eb088e7c",
-        "dest": "nuget-sources",
-        "dest-filename": "system.text.json.4.7.0.nupkg"
+        "dest-filename": "system.text.encodings.web.6.0.0.nupkg"
     },
     {
         "type": "file",
@@ -1548,10 +1121,10 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.text.regularexpressions/4.3.0/system.text.regularexpressions.4.3.0.nupkg",
-        "sha512": "80353c148df30d9a2c03ee10a624d91b64d7ccc3218cb966344cfa70657f0b59c867fed2ab94057f64ab281ad9318353f25c23375c00e1376b6589ae0a70aad3",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.text.json/6.0.5/system.text.json.6.0.5.nupkg",
+        "sha512": "365a854b3a6187af14888fca10573f84c73c9066fec84a25cae233949dcf51ada2efe716ea3d315f8f7cb438ff153ae03ef8ee69e8f24ec3f50971133014e3c0",
         "dest": "nuget-sources",
-        "dest-filename": "system.text.regularexpressions.4.3.0.nupkg"
+        "dest-filename": "system.text.json.6.0.5.nupkg"
     },
     {
         "type": "file",
@@ -1569,13 +1142,6 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.3.0/system.threading.tasks.extensions.4.3.0.nupkg",
-        "sha512": "2c33900ff7f544d6db31ad11b6baee1c9ecb40d5a54f51e5dd5bbbb37f4c50ee35ed481615cbf7c1da61a31ae3333c4454bfbeee4ae32241789e72ce3f910db6",
-        "dest": "nuget-sources",
-        "dest-filename": "system.threading.tasks.extensions.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
         "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.5.3/system.threading.tasks.extensions.4.5.3.nupkg",
         "sha512": "10bb263e21c5aefba554ba6e9adcfcc31f9f3692f675665b58cf76b5a5bcc2133d56eedba94f422b30be9ad251edcfeba7ebc24a15ff4cb7838072e9bbb18470",
         "dest": "nuget-sources",
@@ -1583,59 +1149,31 @@
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.threadpool/4.3.0/system.threading.threadpool.4.3.0.nupkg",
-        "sha512": "450a40f94a48e9396979e764e494ad624d8333f3378b91ea69b23fc836df8f5c43bbd6c8cfd91da2ab95a476e1ff042338968e09b720447f2241c014bfc75159",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.tasks.extensions/4.5.4/system.threading.tasks.extensions.4.5.4.nupkg",
+        "sha512": "68052086e77d3c7198737a3da163d67740b7c44f93250c39659b3bf21b6547a9abf64cbf40481f5c78f24361af3aaf47d52d188b371554a0928a7f7665c1fc14",
         "dest": "nuget-sources",
-        "dest-filename": "system.threading.threadpool.4.3.0.nupkg"
+        "dest-filename": "system.threading.tasks.extensions.4.5.4.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.threading.timer/4.3.0/system.threading.timer.4.3.0.nupkg",
-        "sha512": "d5ce8e258b7be7be268f944e21621195948106f57e6c46e69b2887c46f567760368b14e84046b4be4466ecd08ecd4cb04016a2ff7948cb4640960befc7aa1739",
+        "url": "https://api.nuget.org/v3-flatcontainer/system.windows.extensions/6.0.0/system.windows.extensions.6.0.0.nupkg",
+        "sha512": "f51eec8166f97b5fcea24816ec737c24d5c5a5cb145ef2d33277c9a16044f40bc3fb97b4cfe7f9a23af704ede91586c6abd2acf00b277538bb304d77a1ca54f0",
         "dest": "nuget-sources",
-        "dest-filename": "system.threading.timer.4.3.0.nupkg"
+        "dest-filename": "system.windows.extensions.6.0.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.valuetuple/4.5.0/system.valuetuple.4.5.0.nupkg",
-        "sha512": "fa00ebb5045d12c51274f64411c551981beceb1266a8606a4731063109b95ea1f15939197bf3d2ba899db61e593dc39bfce876908bba34286823525093ae3d8e",
+        "url": "https://api.nuget.org/v3-flatcontainer/tmds.dbus/0.16.0/tmds.dbus.0.16.0.nupkg",
+        "sha512": "b69917eb43d6518efa591702f927e26366ea59cd3d6a7fb397d485970be736b26576f0c16e047c3e9da3d423753a87c91536633d2cc9c60e565e76a2641e3723",
         "dest": "nuget-sources",
-        "dest-filename": "system.valuetuple.4.5.0.nupkg"
+        "dest-filename": "tmds.dbus.0.16.0.nupkg"
     },
     {
         "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.windows.extensions/4.7.0/system.windows.extensions.4.7.0.nupkg",
-        "sha512": "f7bc7cafc5f542a11457a27fdb96ab8a8c8d06851df6d8bc3ac40c2038abc71907feb64ad9ec27ca940d6e51b316f04d2dc3d24cf1b2b5173cde9e20b6aa0709",
+        "url": "https://api.nuget.org/v3-flatcontainer/tmds.dbus.protocol/0.16.0/tmds.dbus.protocol.0.16.0.nupkg",
+        "sha512": "1e6e1bf8ea7c652e5502e96323984157e060ac728843f2104ff8dcab755483ff93ef4df7cc4e7dd4b56047ba42bf349c2681e2fb8d6518328eab002e63d371b2",
         "dest": "nuget-sources",
-        "dest-filename": "system.windows.extensions.4.7.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.readerwriter/4.3.0/system.xml.readerwriter.4.3.0.nupkg",
-        "sha512": "991101497fbd39e43fc306ca280a465318868afa8db1f34bb87c266fe61f0c81a0ec34a797b236ee823bd60d1149b7592def96fe044abb511858efffe890c2e6",
-        "dest": "nuget-sources",
-        "dest-filename": "system.xml.readerwriter.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.xdocument/4.3.0/system.xml.xdocument.4.3.0.nupkg",
-        "sha512": "c2d9236a696daf23a29b530b9aa510fb813041685a1bb9a95845a51e61d870a0615e988b150f5be0d0896ef94b123e97f96c8a43ee815cf5b9897593986b1113",
-        "dest": "nuget-sources",
-        "dest-filename": "system.xml.xdocument.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/system.xml.xmldocument/4.3.0/system.xml.xmldocument.4.3.0.nupkg",
-        "sha512": "22251b3f16de9aa06e091b24baea1b8c95752f0d22266faf34e1fb76b347b23f7910cdaf567058e23d06b7079961090ca70805070a2491add5da4d0271afd133",
-        "dest": "nuget-sources",
-        "dest-filename": "system.xml.xmldocument.4.3.0.nupkg"
-    },
-    {
-        "type": "file",
-        "url": "https://api.nuget.org/v3-flatcontainer/tmds.dbus/0.9.1/tmds.dbus.0.9.1.nupkg",
-        "sha512": "ce70e7c1f24026443010a8999f3b60c72bb7409bccebc915650eff06cb072556948c7c8de9f8fe558a7860213982eddb99a4663b526ea1e2b33e94f80da96110",
-        "dest": "nuget-sources",
-        "dest-filename": "tmds.dbus.0.9.1.nupkg"
+        "dest-filename": "tmds.dbus.protocol.0.16.0.nupkg"
     },
     {
         "type": "file",


### PR DESCRIPTION
Adds a patch to change the Avalonia version to 11.1.0-beta1 instead of a CI build version that already expired.
This also removes `-p:PublishTrimmed=true` from the build command. Not sure why I added it in the first place, since trimming seems to break easily / not work sometimes.